### PR TITLE
Fix link to Feather.js in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ https://github.com/madgrizzle/WebControl/releases
 * [Flask-Socketio](https://github.com/miguelgrinberg/Flask-SocketIO) - Websocket integration for communications with browser clients
 * [Bootstrap4](https://getbootstrap.com/) - Front-end component library
 * [Jinja2](http://jinja.pocoo.org/) - Template engine for web page generation
-* [Feather.js](https://github.com/feathericons/feather/) - Only icon library I could find that had diagonal arrows.. works well to boot.
+* [Feather.js](https://feathericons.com/) - Only icon library I could find that had diagonal arrows.. works well to boot.
 * [OpenCV](https://github.com/skvark/opencv-python) - Library for computer vision to implement optical calibration
 * [Numpy](http://www.numpy.org) - Library for math routines used with optical calibration
 * [Scipy](http://www.scipy.org) - Another library for math routines used with optical calibration

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ https://github.com/madgrizzle/WebControl/releases
 * [Flask-Socketio](https://github.com/miguelgrinberg/Flask-SocketIO) - Websocket integration for communications with browser clients
 * [Bootstrap4](https://getbootstrap.com/) - Front-end component library
 * [Jinja2](http://jinja.pocoo.org/) - Template engine for web page generation
-* [Feather.js](https://feathersjs.com/) - Only icon library I could find that had diagonal arrows.. works well to boot.
+* [Feather.js](https://github.com/feathericons/feather/) - Only icon library I could find that had diagonal arrows.. works well to boot.
 * [OpenCV](https://github.com/skvark/opencv-python) - Library for computer vision to implement optical calibration
 * [Numpy](http://www.numpy.org) - Library for math routines used with optical calibration
 * [Scipy](http://www.scipy.org) - Another library for math routines used with optical calibration

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ Check out the release page at:
 * [Flask-Socketio](https://github.com/miguelgrinberg/Flask-SocketIO) - Websocket integration for communications with browser clients
 * [Bootstrap4](https://getbootstrap.com/) - Front-end component library
 * [Jinja2](http://jinja.pocoo.org/) - Template engine for web page generation
-* [Feather.js](https://github.com/feathericons/feather/) - Only icon library I could find that had diagonal arrows.. works well to boot.
+* [Feather.js](https://feathericons.com/) - Only icon library I could find that had diagonal arrows.. works well to boot.
 * [OpenCV](https://github.com/skvark/opencv-python) - Library for computer vision to implement optical calibration
 * [Numpy](http://www.numpy.org) - Library for math routines used with optical calibration
 * [Scipy](http://www.scipy.org) - Another library for math routines used with optical calibration

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ Check out the release page at:
 * [Flask-Socketio](https://github.com/miguelgrinberg/Flask-SocketIO) - Websocket integration for communications with browser clients
 * [Bootstrap4](https://getbootstrap.com/) - Front-end component library
 * [Jinja2](http://jinja.pocoo.org/) - Template engine for web page generation
-* [Feather.js](https://feathersjs.com/) - Only icon library I could find that had diagonal arrows.. works well to boot.
+* [Feather.js](https://github.com/feathericons/feather/) - Only icon library I could find that had diagonal arrows.. works well to boot.
 * [OpenCV](https://github.com/skvark/opencv-python) - Library for computer vision to implement optical calibration
 * [Numpy](http://www.numpy.org) - Library for math routines used with optical calibration
 * [Scipy](http://www.scipy.org) - Another library for math routines used with optical calibration


### PR DESCRIPTION
Testing upstream pull request with simple fix to README.md which incorrectly links to feathersjs.com (note plural 'feathers').

Sorry I wrongly executed a Merge pull on my forked repo https://github.com/gb0101010101/WebControl with ID "409f20c". Will not do that again.