### PR TITLE
Desktop and Mobile UI improvements

### DIFF
--- a/static/scripts/base.js
+++ b/static/scripts/base.js
@@ -230,6 +230,7 @@ function setupStatusButtons(){
       $('#mobileClientStatus').show();
       $('#mobileCPUUsage').show();
       $('#mobileControllerStatusAlert').show();
+      $('.navbar-brand').hide();
   } else {
     $('#mobileClientStatus').hide();
     $('#mobileCPUUsage').hide();

--- a/static/styles/frontpage.css
+++ b/static/styles/frontpage.css
@@ -143,3 +143,21 @@ html, body{
   100% { background-color: #B20000; box-shadow: 0 0 3px #B20000; }
 }
 
+.controls {
+  align-items: center;
+}
+
+.controls .btn {
+  width: 100%;
+  padding: .375rem .125rem;
+}
+
+.controls label {
+  width: 100%;
+  margin-bottom: auto;
+  text-align: right;
+}
+
+#pauseButton {
+	color: #fff;
+}

--- a/templates/frontpage3d.html
+++ b/templates/frontpage3d.html
@@ -19,58 +19,57 @@
     <div class="flex-fixed-width-item"><!--"col my-sidebar">-->
         <h3>Controls</h3>
         <div>
-        <div class="row">
-          <div class="col mb-1">
+        <div class="controls row">
+          <div class="col-3 mb-1">
             <button type="button" class="btn btn-secondary btn-block disabler" onclick="action('move','upLeft',$('#distToMove').val())"><i data-feather="arrow-up-left"></i></button>
           </div>
-          <div class="col mb-1">
+          <div class="col-3 mb-1">
             <button type="button" class="btn btn-dark btn-block" onclick="action('move','up',$('#distToMove').val())";><i data-feather="arrow-up"></i></button>
           </div>
-          <div class="col mb-1">
+          <div class="col-3 mb-1">
             <button type="button" class="btn btn-secondary btn-block" onclick="action('move','upRight',$('#distToMove').val())"><i data-feather="arrow-up-right"></i></button>
           </div>
-          <div class="col mb-1">
+          <div class="col-3 mb-1">
             <button type="button" class="btn btn-primary btn-block" onclick="action('macro1')">Macro1</button>
           </div>
           <div class="w-100"></div>
-          <div class="col mb-1">
+          <div class="col-3 mb-1">
             <button type="button" class="btn btn-dark btn-block" onclick="action('move','left',$('#distToMove').val())"><i data-feather="arrow-left"></i></button>
           </div>
-          <div class="col mb-1">
+          <div class="col-3 mb-1">
             <button type="button" class="btn btn-dark btn-block" onclick="action('home')"><i data-feather="home"></i></button>
           </div>
-          <div class="col mb-1">
+          <div class="col-3 mb-1">
             <button type="button" class="btn btn-dark btn-block" onclick="action('move','right',$('#distToMove').val())"><i data-feather="arrow-right"></i></button>
           </div>
-          <div class="col mb-1">
+          <div class="col-3 mb-1">
             <button type="button" class="btn btn-primary btn-block" onclick="action('macro2')">Macro2</button>
           </div>
           <div class="w-100"></div>
-          <div class="col mb-1">
+          <div class="col-3 mb-1">
             <button type="button" class="btn btn-secondary btn-block" onclick="action('move','downLeft',$('#distToMove').val())"><i data-feather="arrow-down-left"></i></button>
           </div>
-          <div class="col mb-1">
+          <div class="col-3 mb-1">
             <button type="button" class="btn btn-dark btn-block" onclick="action('move','down',$('#distToMove').val())"><i data-feather="arrow-down"></i></button>
           </div>
-          <div class="col mb-1">
+          <div class="col-3 mb-1">
             <button type="button" class="btn btn-secondary btn-block" onclick="action('move','downRight',$('#distToMove').val())"><i data-feather="arrow-down-right"></i></button>
           </div>
-          <div class="col mb-1">
+          <div class="col-3 mb-1">
             <button type="button" class="btn btn-primary btn-block" onclick="requestPage('zAxis');">ZAxis</button>
           </div>
-        </div>
-        <div class="row">
-          <div class="col mb-1">
-            <label>Dist To Move</label>
+          <div class="w-100"></div>
+          <div class="col-3 mb-1">
+            <label>Distance:</label>
           </div>
           <div class="col-3 mb-1">
             <input class="form-control" type="number" step="any"  id="distToMove" value="0.01">
           </div>
-          <div class="col-2 mb-1">
+          <div class="col-3 mb-1">
             <button id="units" type="button" class="btn btn-secondary" onclick="unitSwitch();">--</button>
           </div>
-          <div class="col-4 mb-1">
-            <button type="button" class="btn btn-primary btn-block" onclick="action('defineHome')" >Def. Home</button>
+          <div class="col-3 mb-1">
+            <button id="btnDefHome" type="button" class="btn btn-primary btn-block" onclick="action('defineHome')" ><i data-feather="save">Def.</i> <i data-feather="home">Home</i></button>
           </div>
         </div>
         <div class="row">

--- a/templates/frontpage3d_mobile.html
+++ b/templates/frontpage3d_mobile.html
@@ -11,90 +11,89 @@
   <script src="{{ url_for('static',filename='scripts/three.js') }}" crossorigin="anonymous"></script>
   <script src="{{ url_for('static',filename='scripts/orbitcontrols.js') }}" crossorigin="anonymous"></script>
   <script src="{{ url_for('static',filename='scripts/frontpage3d.js', version='11102018r') }}" crossorigin="anonymous"></script>
-<script> feather.replace() </script>
+  <script>feather.replace()</script>
 {% endblock %}
 
 {% block content %}
 <div class="container-fluid">
-  <h3>Controls</h3>
-  <div class="row">
-    <div class="col-4  mb-1">
-      <button type="button" class="btn btn-lg btn-secondary btn-block" onclick="action('move','upLeft',$('#distToMove').val())">
-        <i data-feather="arrow-up-left"></i>
-      </button>
+  <div class="controls">
+    <h3>Controls</h3>
+    <div class="row">
+      <div class="col-4  mb-1">
+        <button type="button" class="btn btn-lg btn-secondary btn-block" onclick="action('move','upLeft',$('#distToMove').val())">
+          <i data-feather="arrow-up-left"></i>
+        </button>
+      </div>
+      <div class="col-4  mb-1">
+        <button type="button" class="btn btn-lg btn-dark btn-block" onclick="action('move','up',$('#distToMove').val())">
+          <i data-feather="arrow-up"></i>
+        </button>
+      </div>
+      <div class="col-4  mb-1">
+        <button type="button" class="btn btn-lg btn-secondary btn-block" onclick="action('move','upRight',$('#distToMove').val())">
+          <i data-feather="arrow-up-right"></i>
+        </button>
+      </div>
     </div>
-    <div class="col-4  mb-1">
-      <button type="button" class="btn btn-lg btn-dark btn-block" onclick="action('move','up',$('#distToMove').val())";>
-        <i data-feather="arrow-up"></i>
-      </button>
+    <div class="row">
+      <div class="col-4  mb-1">
+        <button type="button" class="btn btn-lg btn-dark btn-block" onclick="action('move','left',$('#distToMove').val())">
+          <i data-feather="arrow-left"></i>
+        </button>
+      </div>
+      <div class="col-4  mb-1">
+        <button type="button" class="btn btn-lg btn-dark btn-block" onclick="action('home')">
+          <i data-feather="home"></i>
+        </button>
+      </div>
+      <div class="col-4  mb-1">
+        <button type="button" class="btn btn-lg btn-dark btn-block" onclick="action('move','right',$('#distToMove').val())">
+          <i data-feather="arrow-right"></i>
+        </button>
+      </div>
     </div>
-    <div class="col-4  mb-1">
-      <button type="button" class="btn btn-lg btn-secondary btn-block" onclick="action('move','upRight',$('#distToMove').val())">
-        <i data-feather="arrow-up-right"></i>
-      </button>
+    <div class="row">
+      <div class="col-4  mb-1">
+        <button type="button" class="btn btn-lg btn-secondary btn-block" onclick="action('move','downLeft',$('#distToMove').val())">
+          <i data-feather="arrow-down-left"></i>
+        </button>
+      </div>
+      <div class="col-4  mb-1">
+        <button type="button" class="btn btn-lg btn-dark btn-block" onclick="action('move','down',$('#distToMove').val())">
+          <i data-feather="arrow-down"></i>
+        </button>
+      </div>
+      <div class="col-4  mb-1">
+        <button type="button" class="btn btn-lg btn-secondary btn-block" onclick="action('move','downRight',$('#distToMove').val())">
+          <i data-feather="arrow-down-right"></i>
+        </button>
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-4  mb-1">
-      <button type="button" class="btn btn-lg btn-dark btn-block" onclick="action('move','left',$('#distToMove').val())">
-        <i data-feather="arrow-left"></i>
-      </button>
+    <div class="row">
+      <div class="col-4  mb-1">
+        <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('macro1')" >Macro1</button>
+      </div>
+      <div class="col-4  mb-1">
+        <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('macro2')" >Macro2</button>
+      </div>
+      <div class="col-4  mb-1">
+        <button type="button" class="btn btn-lg btn-primary btn-block" onclick="requestPage('zAxis')">ZAxis</button>
+      </div>
     </div>
-    <div class="col-4  mb-1">
-      <button type="button" class="btn btn-lg btn-dark btn-block" onclick="action('home')">
-        <i data-feather="home"></i>
-      </button>
-    </div>
-    <div class="col-4  mb-1">
-      <button type="button" class="btn btn-lg btn-dark btn-block" onclick="action('move','right',$('#distToMove').val())">
-        <i data-feather="arrow-right"></i>
-      </button>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-4  mb-1">
-      <button type="button" class="btn btn-lg btn-secondary btn-block" onclick="action('move','downLeft',$('#distToMove').val())">
-        <i data-feather="arrow-down-left"></i>
-      </button>
-    </div>
-    <div class="col-4  mb-1">
-      <button type="button" class="btn btn-lg btn-dark btn-block" onclick="action('move','down',$('#distToMove').val())">
-        <i data-feather="arrow-down"></i>
-      </button>
-    </div>
-    <div class="col-4  mb-1">
-      <button type="button" class="btn btn-lg btn-secondary btn-block" onclick="action('move','downRight',$('#distToMove').val())">
-        <i data-feather="arrow-down-right"></i>
-      </button>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-4  mb-1">
-      <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('macro1')" >Macro1</button>
-    </div>
-    <div class="col-4  mb-1">
-      <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('macro2')" >Macro2</button>
-    </div>
-    <div class="col-4  mb-1">
-      <button type="button" class="btn btn-lg btn-primary btn-block" onclick="requestPage('zAxis');">ZAxis</button>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-5  mb-1">
-      <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('defineHome')" >Def. Home</button>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-3  mb-1">
-      <label>Dist To Move</label>
-    </div>
-    <div class="col-4  mb-1">
-      <input class="form-control" type="number" id="distToMove" value="0.01">
-    </div>
-    <div class="col-4  mb-1">
-      <button id="units" type="button" class="btn btn-lg btn-secondary" onclick="unitSwitch();">--</button>
+    <div class="row">
+      <div class="col-4  mb-1">
+        <input class="form-control" type="number" id="distToMove" value="0.01">
+      </div>
+      <div class="col-4  mb-1">
+        <button id="units" type="button" class="btn btn-lg btn-secondary" onclick="unitSwitch()">--</button>
+      </div>
+      <div class="col-4  mb-1">
+        <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('defineHome')" >
+        <i data-feather="save">Def.</i> <i data-feather="home">Home</i></button>
+      </div>
     </div>
   </div>
+
   <div class="row">
     <div class="col mb-1">
       <div id="alerts" class="alert alert-success alert-dismissible col-md-12">No alerts</div>
@@ -112,29 +111,29 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-2  mb-1">
+    <div class="col-3  mb-1">
       <button type="button" class="btn btn-md btn-block btn-secondary" onclick="action('moveGcodeZ',-1);">&lt;Z</button>
     </div>
-    <div class="col-2  mb-1">
+    <div class="col-3  mb-1">
       <button type="button" class="btn btn-md btn-block btn-secondary" onclick="action('moveGcodeIndex',-1);">&lt;1</button>
     </div>
-    <div class="col-2  mb-1">
+    <div class="col-3  mb-1">
       <button type="button" class="btn btn-md btn-block btn-secondary" onclick="action('moveGcodeIndex',1);">1&gt;</button>
     </div>
-    <div class="col-2  mb-1">
+    <div class="col-3  mb-1">
       <button type="button" class="btn btn-md btn-block btn-secondary" onclick="action('moveGcodeZ',1);">Z&gt;</button>
     </div>
   </div>
   
   <div class="row align-items-center">
-      <div class="col-3 mb-1">
+      <div class="col-4 mb-1">
         <h5>Line #:</h5>
       </div>
       <div class="col-4 mb-1">
         <input class="form-control" type="number" step="any"  id="gcodeLineIndex" value="1">
       </div>
-      <div class="col-3 mb-1">
-        <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeGoto',$('#gcodeLineIndex').val()-1);")>Goto</button>
+      <div class="col-4 mb-1">
+        <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeGoto',$('#gcodeLineIndex').val()-1)">Goto</button>
       </div>
   </div>
   <div class="row">
@@ -147,7 +146,7 @@
   </div>  
   <div class="row">
     <div class="col-3  mb-1">
-      <h5>Position</h5>
+      <h5>Position:</h5>
     </div>
     <div class="col-9  mb-1">
       <div id='positionMessage'></div>
@@ -205,7 +204,7 @@
   <div id="workarea" class="row" style="height:400px">
   </div>
   <div class="col-3 mb-1">
-    <button id="videoStatus" type="button" class="btn btn-block btn-secondary" onclick="action('toggleCamera');")><i data-feather="video-off"></i></button>
+    <button id="videoStatus" type="button" class="btn btn-block btn-secondary" onclick="action('toggleCamera')"><i data-feather="video-off"></i></button>
   </div>
   <div id="mobileCameraArea" class="row" style="height:200px" style="display:none">
     <div class="col">
@@ -224,14 +223,13 @@
     </div>
   </div>
   <div class="row">
-      <div class="col mb-1">
-        <h3>Controller Messages</h3>
-      </div>
+    <div class="col mb-1">
+      <h3>Controller Messages</h3>
     </div>
-    <div class="row">
-      <div class="col mb-1">
-        <div class="scrollTextMobile" id='controllerMessage'></div>
-      </div>
+  </div>
+  <div class="row">
+    <div class="col mb-1">
+      <div class="scrollTextMobile" id='controllerMessage'></div>
     </div>
   </div>
 </div>

--- a/templates/zaxis.html
+++ b/templates/zaxis.html
@@ -11,7 +11,7 @@
           <button id="unitsZ" type="button" class="btn  btn-lg btn-block btn-secondary" onclick="unitSwitchZ();">{{unitsZ}}</button>
         </div>
         <div class="col-4 mb-1">
-          <button type="button" class="btn btn-lg  btn-block btn-secondary" onclick="action('moveZ','raise',$('#distToMoveZ').val())">Raise</button>
+          <button type="button" class="btn btn-lg  btn-block btn-secondary" onclick="action('moveZ','raise',$('#distToMoveZ').val())"><i data-feather="arrow-up">Raise</i></button>
         </div>
       </div>
       <div class="row">
@@ -19,15 +19,15 @@
           <button type="button" class="btn  btn-lg btn-block btn-secondary" onclick="action('touchZ')" {{'' if touchPlate else 'disabled'}} >Touch</button>
         </div>
         <div class="col-4 mb-1">
-          <button type="button" class="btn  btn-lg btn-block btn-secondary" onclick="action('defineZ0');">Define Zero</button>
+          <button type="button" class="btn  btn-lg btn-block btn-secondary" onclick="action('defineZ0');"><i data-feather="save">Def.</i> Zero</button>
         </div>
         <div class="col-4 mb-1">
-          <button type="button" class="btn  btn-lg btn-block btn-secondary" onclick="action('moveZ','lower',$('#distToMoveZ').val())">Lower</button>
+          <button type="button" class="btn  btn-lg btn-block btn-secondary" onclick="action('moveZ','lower',$('#distToMoveZ').val())"><i data-feather="arrow-down">Lower</i></button>
         </div>
       </div>
     </div>
     <div class="col-3 mb-1">
-      <button type="button" class="btn  btn-lg btn-block btn-danger" style="height:100%" onclick="action('stopZ');">Stop</button>
+      <button type="button" class="btn  btn-lg btn-block btn-danger" style="height:100%" onclick="action('stopZ');"><i data-feather="alert-octagon"></i> Stop</button>
     </div>
   </div>
 </div>
@@ -35,4 +35,6 @@
 
 {% block javascript %}
   <script src="{{ url_for('static',filename='scripts/zAxis.js', version='10262018a') }}" crossorigin="anonymous"></script>
+  <script src="{{ url_for('static',filename='scripts/feather.min.js') }}" crossorigin="anonymous"></script>
+  <script> feather.replace() </script>
 {% endblock %}

--- a/templates/zaxis_mobile.html
+++ b/templates/zaxis_mobile.html
@@ -13,7 +13,7 @@
       </div>
       <div class="row">
         <div class="col-6 mb-1">
-          <button type="button" class="btn btn-lg  btn-block btn-secondary" onclick="action('moveZ','raise',$('#distToMoveZ').val())">Raise</button>
+          <button type="button" class="btn btn-lg  btn-block btn-secondary" onclick="action('moveZ','raise',$('#distToMoveZ').val())"><i data-feather="arrow-up">Raise</i></button>
         </div>
         <div class="col-6 mb-1">
           <button type="button" class="btn  btn-lg btn-block btn-secondary" onclick="action('touchZ')" {{'' if touchPlate else 'disabled'}} >Touch</button>
@@ -21,14 +21,14 @@
       </div>
       <div class="row">
         <div class="col-6 mb-1">
-          <button type="button" class="btn  btn-lg btn-block btn-secondary" onclick="action('moveZ','lower',$('#distToMoveZ').val())">Lower</button>
+          <button type="button" class="btn  btn-lg btn-block btn-secondary" onclick="action('moveZ','lower',$('#distToMoveZ').val())"><i data-feather="arrow-down">Lower</i></button>
         </div>
         <div class="col-6 mb-1">
-          <button type="button" class="btn  btn-lg btn-block btn-secondary" onclick="action('defineZ0');">Define Zero</button>
+          <button type="button" class="btn  btn-lg btn-block btn-secondary" onclick="action('defineZ0');"><i data-feather="save">Def.</i> Zero</button>
         </div>
       </div>
       <div class="col mb-1">
-        <button type="button" class="btn  btn-lg btn-block btn-danger" style="height:100%" onclick="action('stopZ');">Stop</button>
+        <button type="button" class="btn  btn-lg btn-block btn-danger" style="height:100%" onclick="action('stopZ');"><i data-feather="alert-octagon"></i> Stop</button>
       </div>
     </div>
   </div>
@@ -37,4 +37,6 @@
 
 {% block javascript %}
   <script src="{{ url_for('static',filename='scripts/zAxis.js', version='10262019c') }}" crossorigin="anonymous"></script>
+  <script src="{{ url_for('static',filename='scripts/feather.min.js') }}" crossorigin="anonymous"></script>
+  <script> feather.replace() </script>
 {% endblock %}


### PR DESCRIPTION
Made a number of changes to the Desktop and Mobile UI:

**Common:**
1 - Frontpage - Added feather for _Define Home_ button - uses _Save_ and _Home_ icons
2 - Zaxis modal - Added feather icons for _Raise_, _Lower_, _Def. Zero_, and _Stop_ buttons.
3 - Added .controls class to apply styling to control buttons
4 - Changed _Pause_ button text to be white like all others. 

**Desktop:**
1 - Move 4th row buttons into .controls div so that button size is consistently applied.
2 - Changed "Dist. to Move" label to "Distance" so it will fit. Added CSS to right align and vertically center label. This also centers all buttons so that they align properly in the controls div.

**Mobile:**
1 - Fixed errors: Extra closing div at EOF, Extra closing brackets ")" after onclick actions.
2 - Removed  "Dist. to Move" label as it is not needed ad takes up critical space.
3 - Merged 4th & 5th control button rows so that _Distance_ input, _Units_ button, and _Def. Home_ button are all in one row.
4 - Fixed moveGcode buttons to use 4 col grid.
5 - Hide "WebControl" text from _NavBar_ so that all elements fit on one line.

Could also remove "Controls" heading from mobile view.
