### PR TITLE
Fix distToMove input validation to force positive number with max 3 decimals

### DIFF
--- a/static/scripts/frontpage3d.js
+++ b/static/scripts/frontpage3d.js
@@ -872,3 +872,13 @@ function toggleBoard(){
     }
 }
 
+function moveAction(direction) {
+	distance = $("#distToMove").val();
+	distanceValid = distance.search(/^[0-9]*(\.[0-9]{0,3})?$/);
+	if (distanceValid == 0) {
+		action('move', direction, distance);
+	} else {
+		$("#distToMove").focus();
+	}
+}
+

--- a/templates/frontpage3d.html
+++ b/templates/frontpage3d.html
@@ -21,39 +21,39 @@
         <div>
         <div class="controls row">
           <div class="col-3 mb-1">
-            <button type="button" class="btn btn-secondary btn-block disabler" onclick="action('move','upLeft',$('#distToMove').val())"><i data-feather="arrow-up-left"></i></button>
+            <button type="button" class="btn btn-secondary btn-block disabler" onclick="moveAction('upLeft')"><i data-feather="arrow-up-left"></i></button>
           </div>
           <div class="col-3 mb-1">
-            <button type="button" class="btn btn-dark btn-block" onclick="action('move','up',$('#distToMove').val())";><i data-feather="arrow-up"></i></button>
+            <button type="button" class="btn btn-dark btn-block" onclick="moveAction('up')"><i data-feather="arrow-up"></i></button>
           </div>
           <div class="col-3 mb-1">
-            <button type="button" class="btn btn-secondary btn-block" onclick="action('move','upRight',$('#distToMove').val())"><i data-feather="arrow-up-right"></i></button>
+            <button type="button" class="btn btn-secondary btn-block" onclick="moveAction('upRight')"><i data-feather="arrow-up-right"></i></button>
           </div>
           <div class="col-3 mb-1">
             <button type="button" class="btn btn-primary btn-block" onclick="action('macro1')">Macro1</button>
           </div>
           <div class="w-100"></div>
           <div class="col-3 mb-1">
-            <button type="button" class="btn btn-dark btn-block" onclick="action('move','left',$('#distToMove').val())"><i data-feather="arrow-left"></i></button>
+            <button type="button" class="btn btn-dark btn-block" onclick="moveAction('left')"><i data-feather="arrow-left"></i></button>
           </div>
           <div class="col-3 mb-1">
             <button type="button" class="btn btn-dark btn-block" onclick="action('home')"><i data-feather="home"></i></button>
           </div>
           <div class="col-3 mb-1">
-            <button type="button" class="btn btn-dark btn-block" onclick="action('move','right',$('#distToMove').val())"><i data-feather="arrow-right"></i></button>
+            <button type="button" class="btn btn-dark btn-block" onclick="moveAction('right')"><i data-feather="arrow-right"></i></button>
           </div>
           <div class="col-3 mb-1">
             <button type="button" class="btn btn-primary btn-block" onclick="action('macro2')">Macro2</button>
           </div>
           <div class="w-100"></div>
           <div class="col-3 mb-1">
-            <button type="button" class="btn btn-secondary btn-block" onclick="action('move','downLeft',$('#distToMove').val())"><i data-feather="arrow-down-left"></i></button>
+            <button type="button" class="btn btn-secondary btn-block" onclick="moveAction('downLeft')"><i data-feather="arrow-down-left"></i></button>
           </div>
           <div class="col-3 mb-1">
-            <button type="button" class="btn btn-dark btn-block" onclick="action('move','down',$('#distToMove').val())"><i data-feather="arrow-down"></i></button>
+            <button type="button" class="btn btn-dark btn-block" onclick="moveAction('down')"><i data-feather="arrow-down"></i></button>
           </div>
           <div class="col-3 mb-1">
-            <button type="button" class="btn btn-secondary btn-block" onclick="action('move','downRight',$('#distToMove').val())"><i data-feather="arrow-down-right"></i></button>
+            <button type="button" class="btn btn-secondary btn-block" onclick="moveAction('downRight')"><i data-feather="arrow-down-right"></i></button>
           </div>
           <div class="col-3 mb-1">
             <button type="button" class="btn btn-primary btn-block" onclick="requestPage('zAxis');">ZAxis</button>
@@ -63,7 +63,7 @@
             <label>Distance:</label>
           </div>
           <div class="col-3 mb-1">
-            <input class="form-control" type="number" step="any"  id="distToMove" value="0.01">
+            <form id="distInput" onsubmit="return false;"><input class="form-control" type="text" pattern="^[0-9]*(\.[0-9]{0,3})?$" id="distToMove" title="Positive number with maximum 3 decimal places"></form>
           </div>
           <div class="col-3 mb-1">
             <button id="units" type="button" class="btn btn-secondary" onclick="unitSwitch();">--</button>

--- a/templates/frontpage3d_mobile.html
+++ b/templates/frontpage3d_mobile.html
@@ -20,24 +20,24 @@
     <h3>Controls</h3>
     <div class="row">
       <div class="col-4  mb-1">
-        <button type="button" class="btn btn-lg btn-secondary btn-block" onclick="action('move','upLeft',$('#distToMove').val())">
+        <button type="button" class="btn btn-lg btn-secondary btn-block" onclick="moveAction('upLeft')">
           <i data-feather="arrow-up-left"></i>
         </button>
       </div>
       <div class="col-4  mb-1">
-        <button type="button" class="btn btn-lg btn-dark btn-block" onclick="action('move','up',$('#distToMove').val())">
+        <button type="button" class="btn btn-lg btn-dark btn-block" onclick="moveAction('up')">
           <i data-feather="arrow-up"></i>
         </button>
       </div>
       <div class="col-4  mb-1">
-        <button type="button" class="btn btn-lg btn-secondary btn-block" onclick="action('move','upRight',$('#distToMove').val())">
+        <button type="button" class="btn btn-lg btn-secondary btn-block" onclick="moveAction('upRight')">
           <i data-feather="arrow-up-right"></i>
         </button>
       </div>
     </div>
     <div class="row">
       <div class="col-4  mb-1">
-        <button type="button" class="btn btn-lg btn-dark btn-block" onclick="action('move','left',$('#distToMove').val())">
+        <button type="button" class="btn btn-lg btn-dark btn-block" onclick="moveAction('left')">
           <i data-feather="arrow-left"></i>
         </button>
       </div>
@@ -47,24 +47,24 @@
         </button>
       </div>
       <div class="col-4  mb-1">
-        <button type="button" class="btn btn-lg btn-dark btn-block" onclick="action('move','right',$('#distToMove').val())">
+        <button type="button" class="btn btn-lg btn-dark btn-block" onclick="moveAction('right')">
           <i data-feather="arrow-right"></i>
         </button>
       </div>
     </div>
     <div class="row">
       <div class="col-4  mb-1">
-        <button type="button" class="btn btn-lg btn-secondary btn-block" onclick="action('move','downLeft',$('#distToMove').val())">
+        <button type="button" class="btn btn-lg btn-secondary btn-block" onclick="moveAction('downLeft')">
           <i data-feather="arrow-down-left"></i>
         </button>
       </div>
       <div class="col-4  mb-1">
-        <button type="button" class="btn btn-lg btn-dark btn-block" onclick="action('move','down',$('#distToMove').val())">
+        <button type="button" class="btn btn-lg btn-dark btn-block" onclick="moveAction('down')">
           <i data-feather="arrow-down"></i>
         </button>
       </div>
       <div class="col-4  mb-1">
-        <button type="button" class="btn btn-lg btn-secondary btn-block" onclick="action('move','downRight',$('#distToMove').val())">
+        <button type="button" class="btn btn-lg btn-secondary btn-block" onclick="moveAction('downRight')">
           <i data-feather="arrow-down-right"></i>
         </button>
       </div>
@@ -82,7 +82,7 @@
     </div>
     <div class="row">
       <div class="col-4  mb-1">
-        <input class="form-control" type="number" id="distToMove" value="0.01">
+        <form onsubmit="return false;"><input class="form-control" type="text" pattern="^[0-9]*(\.[0-9]{0,3})?$" id="distToMove" title="Positive number with maximum 3 decimal places"></form>
       </div>
       <div class="col-4  mb-1">
         <button id="units" type="button" class="btn btn-lg btn-secondary" onclick="unitSwitch()">--</button>

--- a/templates/frontpage3d_mobile.html
+++ b/templates/frontpage3d_mobile.html
@@ -82,7 +82,7 @@
     </div>
     <div class="row">
       <div class="col-4  mb-1">
-        <form onsubmit="return false;"><input class="form-control" type="text" pattern="^[0-9]*(\.[0-9]{0,3})?$" id="distToMove" title="Positive number with maximum 3 decimal places"></form>
+        <form onsubmit="return false;"><input class="form-control" type="text" inputmode="decimal" pattern="^[0-9]*(\.[0-9]{0,3})?$" id="distToMove" title="Positive number with maximum 3 decimal places"></form>
       </div>
       <div class="col-4  mb-1">
         <button id="units" type="button" class="btn btn-lg btn-secondary" onclick="unitSwitch()">--</button>


### PR DESCRIPTION
The distToMove input box has HTML5 input validation that is not working properly and stops any input  because it currently wants a number in pattern 'N.01' . e.g. '4.01', '6.01' are valid but the following are not:

- 1, 2, 3 etc
- 1.0, 2.0, 3.0 etc
- 1.02, 2.02, 3.02 etc

The current message displayed is:
`Please select a valid  value. The two nearest valid values are 1.01 and 2.01`

On top of that the current "Action('Move'...)" JavaScript does not enforce the input validation and sends bad inputs to the controller. The controller does try to convert the input to a valid float which can lead to unexpected results.

I have changed the HTML5 validation to a pattern match that works for any positive number with a maximum of 3 decimal places. Also changed JavaScript to check input, focus the input box if bad input, and not send the bad input.

The new error message is:
`Please match the requested format: Positive number with maximum 3 decimal places`
(Text before : is defined by browser)

There probably is a better way of coding this so that the pattern is not repeated in code and there is graceful degradation if HTML5 is not supported (is HTML5 required for Webcontrol to work?).
  
The added form with onsubmit is required for HTML5 validation to take place and not reload the page. 

Unfortunately Firefox mobile brings up the standard keyboard as it does not yet support inputmode attribute. 
