### PR TITLE
Make Play, Pause/Resume, and Stop buttons sticky (always visisble) on Mobile

### DIFF
--- a/static/scripts/frontpage3d.js
+++ b/static/scripts/frontpage3d.js
@@ -323,6 +323,7 @@ $(document).ready(function(){
             requestPage("screenAction",pos)
         }
     });
+    $("#stickyButtons").css("top", $(".navbar").outerHeight());
 });
 
 function pauseRun(){

--- a/static/styles/frontpage.css
+++ b/static/styles/frontpage.css
@@ -164,3 +164,10 @@ html, body{
 
 #controllerMessage { overflow-wrap: anywhere; }
 
+#stickyButtons {
+  position: sticky;
+  top: 0px;
+  z-index:1020;
+  background-color: #FFF;
+}
+

--- a/static/styles/frontpage.css
+++ b/static/styles/frontpage.css
@@ -166,8 +166,11 @@ html, body{
 
 #stickyButtons {
   position: sticky;
+  position: -webkit-sticky;
+  position: -moz-sticky;
+  position: -ms-sticky;
+  position: -o-sticky;
   top: 0px;
   z-index:1020;
   background-color: #FFF;
 }
-

--- a/templates/frontpage3d_mobile.html
+++ b/templates/frontpage3d_mobile.html
@@ -99,7 +99,7 @@
       <div id="alerts" class="alert alert-success alert-dismissible col-md-12">No alerts</div>
     </div>
   </div>
-  <div class="row">
+  <div class="row" id="stickyButtons">
     <div class="col-4  mb-1">
       <button type="button" class="btn btn-lg btn-block btn-success" onclick="action('startRun')">Play</button>
     </div>


### PR DESCRIPTION
IMHO the _Pause_ and _Stop_ buttons are the most important UI elements and should always be visible on screen so the user can instantly deal with a Maslow problem. This change makes them stick to the top of the screen under the NavBar.

Following KISS protocol:
- Minimal code change
- Only for mobile devices
- Auto adjust for _NavBar_ height
- Works for portrait and landscape orientation
- Should be browser cross compatible (Not tested on iPhone)

In image below the _Play_, _Pause_, _Stop_ buttons appear big but this change does not resize them. 
Note absence of _gCode move_ buttons (<Z , <1, 1>, > Z), normally under these buttons and above _Line #_.

![Webcontrol_StickyButtons_after_scaled](https://user-images.githubusercontent.com/7369439/72691665-fe7bda80-3adb-11ea-84b4-7f374b28aa1f.png)
