### PR TITLE
Make all mobile menu items collapse the menu when clicked.

### DIFF
--- a/static/scripts/base.js
+++ b/static/scripts/base.js
@@ -8,7 +8,12 @@ if(/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine
   isMobile = true;
 }
 
-
+$(document).ready(function(){
+	// Make all navbar drop down items collapse the menu when clicked.
+	if (isMobile) {
+		$("#navbarSupportedContent a.dropdown-item").attr("data-toggle", "collapse").attr("data-target", "#navbarSupportedContent");
+	}
+})
 
 function processHealthMessage(data){
     //console.log(data.cpuUsage);


### PR DESCRIPTION
Currently the mobile menu does not collapse leaveing the _G-code, Actions, Settings_ etc menu items visible when any sub menu item is clicked.

This change fixes that by adding "data-toggle" and "data-target" attributes to all the dropdown links making them collapse the menu. This is only applied on mobile as it can introduce weird menu animations and flickering on desktop.