### PR TITLE
gCode Editor: Strip trailing whitespace

### DIFF
--- a/WebPageProcessor/webPageProcessor.py
+++ b/WebPageProcessor/webPageProcessor.py
@@ -366,7 +366,7 @@ class WebPageProcessor:
             for line in self.data.gcode:
                 text = text + line + "\n"
             #text = self.gcodePreProcessor()
-            page = render_template("editGCode.html", gcode=text, pageID="editGCode",)
+            page = render_template("editGCode.html", gcode=text.rstrip(), pageID="editGCode",)
             return page, "Edit GCode", True, "medium", "content", "footerSubmit"
         elif pageID == "sendGCode":
             text = self.data.sentCustomGCode

--- a/main.py
+++ b/main.py
@@ -362,7 +362,7 @@ def sendGcode():
     app.data.logger.resetIdler()
     #print(request.form)#["gcodeInput"])
     if request.method == "POST":
-        returnVal = app.data.actions.sendGCode(request.form["gcode"])
+        returnVal = app.data.actions.sendGCode(request.form["gcode"].rstrip())
         if returnVal:
             message = {"status": 200}
             resp = jsonify("success")
@@ -464,7 +464,7 @@ def editGCode():
     app.data.logger.resetIdler()
     #print(request.form["gcode"])
     if request.method == "POST":
-        returnVal = app.data.actions.updateGCode(request.form["gcode"])
+        returnVal = app.data.actions.updateGCode(request.form["gcode"].rstrip())
         if returnVal:
             message = {"status": 200}
             resp = jsonify("success")

--- a/templates/editGCode.html
+++ b/templates/editGCode.html
@@ -1,8 +1,7 @@
 {% block content %}
 <input id="pageID" type="hidden" value="{{pageID}}">
 <div class="container-fluid">
-  <pre id="editor">{{gcode}}
-  </pre>
+  <pre id="editor">{{gcode}}</pre>
 </div>
 {% endblock %}
 
@@ -12,6 +11,7 @@
     var editor = ace.edit("editor");
     editor.setTheme("ace/theme/twilight");
     editor.session.setMode({path: "ace/mode/gcode", v: Date.now()});
+    editor.session.setNewLineMode("unix")
 </script>
 
 <script>


### PR DESCRIPTION
Every time a gcode file is loaded, edited, and saved; new lines were being append to it. This fix strips trailing whitespace each time to stop this.