### PR TITLE
Desktop layout fixes to be fully fluid with no hardcoded pixel dimensions

### DIFF
--- a/static/scripts/frontpage3d.js
+++ b/static/scripts/frontpage3d.js
@@ -11,7 +11,7 @@ var homeY = 0;
 
 var renderer = new THREE.WebGLRenderer();
 var w = $("#workarea").width();//-20;
-var h = $("#workarea").height();//-20;
+var h = $("#workarea").height()- 10;//-20;
 renderer.setSize( w, h );
 //console.log("w="+w+", h="+h);
 
@@ -245,26 +245,25 @@ animate();
 window.addEventListener( 'resize', onWindowResize, false );
 
 function onWindowResize(){
-
-    //w=window.innerWidth;
-    //h=window.innerHeight;
-    //console.log("wr="+w+", hr="+h);
-    we = $("#workarea").width(); //-20;
-    he = $("#workarea").height(); //-20;
+    // Make canvas tiny so the container can shrink.
+    renderer.setSize( 10, 10 );
+    // Get new size of fluid container.
+    we = $("#workarea").width();
+    // Can't find the source of this 10px offset.
+    // Needed to stop unneccesary scrool bar on main window.
+    he = $("#workarea").height() - 10;
     //console.log("we="+we+", he="+he);
 
-    //cameraO.aspect = window.innerWidth / window.innerHeight;
     cameraO.left = we/-2*scale;
     cameraO.right = we/2*scale;
     cameraO.top = he/2*scale;
     cameraO.bottom = he/-2*scale;
     cameraO.updateProjectionMatrix();
-    //cameraP.aspect = window.innerWidth / window.innerHeight;
+
     cameraP.aspect = we / he;
     cameraP.updateProjectionMatrix();
-
+    // Finally resize the canvas.
     renderer.setSize( we, he );
-
 }
 
 

--- a/static/styles/base.css
+++ b/static/styles/base.css
@@ -1,7 +1,7 @@
- .modalxlg > .modal-dialog {
-       max-width: 90% !important;
-      width: 90% !important;
- }
+.modalxlg>.modal-dialog {
+  max-width: 90% !important;
+  width: 90% !important;
+}
 
 .disabler {
 }
@@ -9,93 +9,92 @@
 .alert {
   margin-bottom: 1px;
   height: 30px;
-  line-height:30px;
-  padding:0px 15px;
+  line-height: 30px;
+  padding: 0px 15px;
 }
 
- 
 #contentModalText {
-    max-height: 70vh;
-    overflow-y: auto;
+  max-height: 70vh;
+  overflow-y: auto;
 }
 
 #fpCircle {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%,-50%);
-	width: 150px;
-    height: 150px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 150px;
+  height: 150px;
 }
+
 #gcCircle {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%,-50%);
-	width: 150px;
-    height: 150px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 150px;
+  height: 150px;
 }
+
 #notificationCircle {
-    position: absolute;
-    top: 70%;
-    left: 50%;
-    transform: translate(-50%,-30%);
-	width: 80px;
-    height: 80px;
+  position: absolute;
+  top: 70%;
+  left: 50%;
+  transform: translate(-50%, -30%);
+  width: 80px;
+  height: 80px;
 }
 
 #notificationModal {
-    z-index: 1051;
+  z-index: 1051;
 }
 
-
 .loader {
-    width: calc(100% - 0px);
-	height: calc(100% - 0px);
-	border: 8px solid #162534;
-	border-top: 8px solid #09f;
-	border-radius: 50%;
-	animation: rotate 5s linear infinite;
+  width: calc(100% - 0px);
+  height: calc(100% - 0px);
+  border: 8px solid #162534;
+  border-top: 8px solid #09f;
+  border-radius: 50%;
+  animation: rotate 5s linear infinite;
 }
 
 @keyframes rotate {
 100% {transform: rotate(360deg);}
 }
 
- #editor {
-        margin: 0;
-        position: relative;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        height: 60vh;
-    }
+#editor {
+  margin: 0;
+  position: relative;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 60vh;
+}
 
 .alert-circle.alert-sm {
-    width: 16px;
-    height: 16px;
-    padding: 6px 0px;
-    border-radius: 8px;
-    font-size: 8px;
-    text-align: center;
+  width: 16px;
+  height: 16px;
+  padding: 6px 0px;
+  border-radius: 8px;
+  font-size: 8px;
+  text-align: center;
 }
 
 .dot {
-    height: 15px;
-    width: 15px;
-    background-color: red;
-    border-radius: 50%;
-    display: inline-block;
-  }
+  height: 15px;
+  width: 15px;
+  background-color: red;
+  border-radius: 50%;
+  display: inline-block;
+}
 
-input::-webkit-outer-spin-button,
-input::-webkit-inner-spin-button {
-    /* display: none; <- Crashes Chrome on hover */
-    -webkit-appearance: none;
-    margin: 0; /* <-- Apparently some margin are still there even though it's hidden */
+input::-webkit-outer-spin-button, input::-webkit-inner-spin-button {
+  /* display: none; <- Crashes Chrome on hover */
+  -webkit-appearance: none;
+  margin: 0; /* <-- Apparently some margin are still there even though it's hidden */
 }
 
 input[type=number] {
-    -moz-appearance:textfield; /* Firefox */
+  -moz-appearance: textfield; /* Firefox */
 }

--- a/static/styles/frontpage.css
+++ b/static/styles/frontpage.css
@@ -1,107 +1,105 @@
 .my-sidebar {
-    -ms-flex: 0 0 460px;
-    flex: 0 0 460px;
-    height: calc(100vh - 85px)
+  -ms-flex: 0 0 460px;
+  flex: 0 0 460px;
+  height: calc(100vh - 85px)
 }
 
 .flex-fixed-width-item {
-    flex: 0 0 410px;
-    height: calc(100vh - 85px);
+  flex: 0 0 410px;
+  height: calc(100vh - 85px);
 }
 
 .text-nowrap {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .btn-wrap {
-    white-space: normal !important;
+  white-space: normal !important;
 }
 
 .scrollText {
-    height: calc(100vh - 750px);
-    overflow-y: scroll;
+  height: calc(100vh - 750px);
+  overflow-y: scroll;
 }
 
 .scrollTextMobile {
-    height: 400px;
-    overflow-y: scroll;
+  height: 400px;
+  overflow-y: scroll;
 }
 
 .container-fluid {
 }
 
-html, body{
+html, body {
   height: 100vh;
 }
 
 .flex-fill {
-  flex:1;
+  flex: 1;
 }
 
 .fullWorkArea {
-    height: calc(100vh - 85px);
-    cursor: none;
+  height: calc(100vh - 85px);
+  cursor: none;
 }
 
 /*#button3D, #buttonReset {*/
-#button3DResetGroup{
-    position: absolute;
-    /*display: inline-block;*/
-    z-index: 95;
-    left: 1%;
-
-}
-
-#cursorPosition{
-    width: 125px;
+#button3DResetGroup {
+  position: absolute;
+  /*display: inline-block;*/
+  z-index: 95;
+  left: 1%;
 }
 
 #cursorPosition {
-    cursor: none;
+  width: 125px;
+}
+
+#cursorPosition {
+  cursor: none;
 }
 
 #cameraDiv1 {
-    position: absolute;
-    display: block;
-    z-index: 95;
-    top: 77%;
-    left: 1%;
-    width: 256;
-    height: 192;
+  position: absolute;
+  display: block;
+  z-index: 95;
+  top: 77%;
+  left: 1%;
+  width: 256;
+  height: 192;
 }
 
 #cameraDiv2 {
-    position: absolute;
-    display: block;
-    z-index: 94;
-    top: 77%;
-    left: 1%;
-    width: 256;
-    height: 192;
+  position: absolute;
+  display: block;
+  z-index: 94;
+  top: 77%;
+  left: 1%;
+  width: 256;
+  height: 192;
 }
 
 #mobileCameraDiv1 {
-    position: absolute;
-    display: block;
-    z-index: 95;
-    top: 0%;
-    left: 0%;
-    width: 100%;
-    height: 200;
+  position: absolute;
+  display: block;
+  z-index: 95;
+  top: 0%;
+  left: 0%;
+  width: 100%;
+  height: 200;
 }
 
 #mobileCameraDiv2 {
-    position: absolute;
-    display: block;
-    z-index: 94;
-    top: 0%;
-    left: 0%;
-    width: 100%;
-    height: 200;
+  position: absolute;
+  display: block;
+  z-index: 94;
+  top: 0%;
+  left: 0%;
+  width: 100%;
+  height: 200;
 }
-
 
 .stopbutton {
   background-color: #004A7F;
@@ -119,6 +117,7 @@ html, body{
   -o-animation: glowing 1500ms infinite;
   animation: glowing 1500ms infinite;
 }
+
 @-webkit-keyframes glowing {
   0% { background-color: #B20000; -webkit-box-shadow: 0 0 3px #B20000; }
   50% { background-color: #FF0000; -webkit-box-shadow: 0 0 40px #FF0000; }
@@ -159,10 +158,12 @@ html, body{
 }
 
 #pauseButton {
-	color: #fff;
+  color: #fff;
 }
 
-#controllerMessage { overflow-wrap: anywhere; }
+#controllerMessage {
+  overflow-wrap: anywhere;
+}
 
 #stickyButtons {
   position: sticky;
@@ -171,6 +172,6 @@ html, body{
   position: -ms-sticky;
   position: -o-sticky;
   top: 0px;
-  z-index:1020;
+  z-index: 1020;
   background-color: #FFF;
 }

--- a/static/styles/frontpage.css
+++ b/static/styles/frontpage.css
@@ -4,9 +4,8 @@
   height: calc(100vh - 85px)
 }
 
-.flex-fixed-width-item {
+.sidebar {
   flex: 0 0 410px;
-  height: calc(100vh - 85px);
 }
 
 .text-nowrap {
@@ -20,7 +19,6 @@
 }
 
 .scrollText {
-  height: calc(100vh - 750px);
   overflow-y: scroll;
 }
 
@@ -29,19 +27,11 @@
   overflow-y: scroll;
 }
 
-.container-fluid {
-}
-
 html, body {
-  height: 100vh;
-}
-
-.flex-fill {
-  flex: 1;
+  height: 100%;
 }
 
 .fullWorkArea {
-  height: calc(100vh - 85px);
   cursor: none;
 }
 
@@ -162,7 +152,13 @@ html, body {
 }
 
 #controllerMessage {
-  overflow-wrap: anywhere;
+  position: absolute;
+  overflow: auto;
+  min-height: 150px;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
 }
 
 #stickyButtons {

--- a/static/styles/frontpage.css
+++ b/static/styles/frontpage.css
@@ -20,7 +20,7 @@
 }
 
 .scrollText {
-    height: calc(100vh - 740px);
+    height: calc(100vh - 750px);
     overflow-y: scroll;
 }
 

--- a/static/styles/switches.css
+++ b/static/styles/switches.css
@@ -110,10 +110,6 @@
   margin-left: 1rem;
 }
 
-body {
-  padding-top: 70px;
-}
-
 .dropdown-menu {
   margin-top: .75rem;
 }

--- a/templates/archive/frontpage_mobile.html
+++ b/templates/archive/frontpage_mobile.html
@@ -1,7 +1,10 @@
 {% extends 'base.html' %}
 
-{% block header %}
+{% block head %}
   <link rel="stylesheet" href="{{ url_for('static',filename='styles/frontpage.css', version='10262019a') }}" crossorigin="anonymous">
+{% endblock %}
+
+{% block header %}
   <meta name="viewport" content="width=device-width, initial-scale=1">
 {% endblock %}
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,15 +5,7 @@
   <link rel="stylesheet" href="{{ url_for('static',filename='styles/bootstrap.min.css', version='10262018a') }}" crossorigin="anonymous">
   <link rel="stylesheet" href="{{ url_for('static',filename='styles/switches.css', version='10262018a') }}" crossorigin="anonymous">
   <link rel="stylesheet" href="{{ url_for('static',filename='styles/base.css', version='10262019l') }}" crossorigin="anonymous">
-  <script src="{{ url_for('static',filename='scripts/socket.io-2.1.1.js', version='11102018a') }}" crossorigin="anonymous"></script>
-  <script src="{{ url_for('static',filename='scripts/jquery-3.3.1.min.js', version='11102018a') }}" crossorigin="anonymous"></script>
-  <script src="{{ url_for('static',filename='scripts/bootstrap.bundle.min.js', version='11102018a') }}" crossorigin="anonymous"></script>
-  <script src="{{ url_for('static',filename='scripts/baseSocket.js', version='11102018t') }}" crossorigin="anonymous"></script>
-  <script src="{{ url_for('static',filename='scripts/base.js', version='11102018t') }}" crossorigin="anonymous"></script>
-
-  <script type="text/javascript" charset="utf-8">
-  </script>
-
+  {% block head %}{% endblock %}
 </head>
 <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top" data-name="">
     <a class="navbar-brand" href="#">WebControl</a>
@@ -180,6 +172,11 @@
       </div>
     </div>
   </div>
-</body>
 
-{% block javascript %}{% endblock %}
+  <script src="{{ url_for('static',filename='scripts/socket.io-2.1.1.js', version='11102018a') }}" crossorigin="anonymous"></script>
+  <script src="{{ url_for('static',filename='scripts/jquery-3.3.1.min.js', version='11102018a') }}" crossorigin="anonymous"></script>
+  <script src="{{ url_for('static',filename='scripts/bootstrap.bundle.min.js', version='11102018a') }}" crossorigin="anonymous"></script>
+  <script src="{{ url_for('static',filename='scripts/baseSocket.js', version='11102018t') }}" crossorigin="anonymous"></script>
+  <script src="{{ url_for('static',filename='scripts/base.js', version='11102018t') }}" crossorigin="anonymous"></script>
+  {% block javascript %}{% endblock %}
+</body>

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,98 +7,68 @@
   <link rel="stylesheet" href="{{ url_for('static',filename='styles/base.css', version='10262019l') }}" crossorigin="anonymous">
   {% block head %}{% endblock %}
 </head>
-<nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top" data-name="">
-    <a class="navbar-brand" href="#">WebControl</a>
-    <!--<button id="mobileClientStatus" class="btn btn-outline-danger my-2 my-sm-0" type="button"><i data-feather="alert-circle"></i></button>-->
-    <div id="mobileClientStatus" class="alert alert-danger alert-sm"><i data-feather="alert-circle"></i></div>
-    <!--<div id="mobileClientActivity" class="alert alert-dark alert-circle alert-sm"></div>-->
-    <div id="mobileCPUUsage" class="alert alert-success alert-sm">0%</div>
-    <div id="mobileBufferSize" class="alert alert-success alert-sm" style="display:none">-</div>
-    <!--<button id="mobileControllerStatus" class="btn btn-outline-danger my-2 my-sm-0" type="button"><i data-feather="alert-circle"></i></button>-->
-    <div id="mobileControllerStatusAlert" style="display:none" class="alert alert-danger alert-sm"><i data-feather="alert-circle"></i></div>
-    <button id="mobileControllerStatusButton" style="display:none" type="button" class="btn btn-sm btn-danger" onclick="requestPage('fakeServo');"><i id="mobileControllerStatusButtonIcon" data-feather="check-circle"></i></button>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarSupportedContent">
-      <ul class="navbar-nav mr-auto">
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown1" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            G-Code
-          </a>
-          <div class="dropdown-menu" aria-labelledby="navbarDropdown1">
-            <a class="dropdown-item" href="#" onclick="requestPage('openGCode');">Open</a>
-            <a class="dropdown-item" href="#" onclick="requestPage('saveGCode');">Save</a>
-            <a class="dropdown-item" href="#" onclick="requestPage('uploadGCode');">Upload</a>
-            <a class="dropdown-item" href="#" onclick="action('clearGCode');">Clear GCode</a>
-            <a class="dropdown-item" href="#" onclick="requestPage('editGCode');">View/Edit</a>
-            <a class="dropdown-item" href="#" onclick="requestPage('sendGCode');">Send Custom GCode</a>
-            <!--<a class="dropdown-item" href="#" onclick="action('optimizeGCode');">Optimize GCode</a>-->
-          </div>
-        </li>
-        <li class="nav-item" id="actionsNavItem">
-            <a class="nav-link" href="#" onclick="requestPage('actions');">Actions</a>
-        </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown2" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Settings
-          </a>
-          <div class="dropdown-menu" aria-labelledby="navbarDropdown2">
-            <a class="dropdown-item" href="#" onclick="requestPage('maslowSettings');">Maslow Settings</a>
-            <a class="dropdown-item" href="#" onclick="requestPage('advancedSettings');">Advanced Settings</a>
-            <a class="dropdown-item" href="#" onclick="requestPage('webControlSettings');">WebControl Settings</a>
-            <a class="dropdown-item" href="#" onclick="requestPage('cameraSettings');">Camera Settings</a>
-            <a class="dropdown-item" href="#" onclick="requestPage('gpioSettings');">GPIO Settings</a>
-          </div>
-        </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown3" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Boards
-          </a>
-          <div class="dropdown-menu" aria-labelledby="navbarDropdown3">
-            <a class="dropdown-item" href="#" onclick="requestPage('openBoard');">Open Board</a>
-            <a class="dropdown-item" href="#" onclick="requestPage('saveBoard');">Save Board</a>
-            <a class="dropdown-item" href="#" onclick="requestPage('editBoard');">Create/Edit Board</a>
-            <a class="dropdown-item" href="#" onclick="requestPage('trimBoard');">Trim Board</a>
-            <a class="dropdown-item" href="#" onclick="action('boardProcessGCode');">Process GCode</a>
-            <a class="dropdown-item" href="#" onclick="action('boardClearBoard');">Clear Board</a>
-          </div>
-        </li>
-        <li class="nav-item dropdown">
-          <span id="helpBadge" class="badge badge-pill badge-primary" style="float:left;margin-bottom:-10px;"></span>
-          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown4" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Help
-          </a>
-          <div class="dropdown-menu" aria-labelledby="navbarDropdown4">
-            <a class="dropdown-item" href="#" onclick="requestPage('gettingStarted');">Getting Started</a>
-            <a class="dropdown-item" href="https://madgrizzle.github.io/WebControl/" target="_blank">Online Help</a>
-            <a class="dropdown-item" href="#" onclick="requestPage('help');">Offline Help</a>
-            <a class="dropdown-item" href="#" onclick="requestPage('about');">About</a>
-            <span id="updateBadge" class="badge badge-pill badge-primary" style="float:left;margin-bottom:-10px;"></span>
-            <a class="dropdown-item" href="#" onclick="requestPage('releases');">Update</a>
-            <a class="dropdown-item" href="logs" target="_blank">Logs</a>
-        </div>
-        </li>
-      </ul>
-      <div id="clientStatus" class="alert alert-danger">Not Connect</div>
-      <!--<div id="activity" class="alert alert-success alert-circle alert-sm"></div>-->
-      <div id="cpuUsage" class="alert alert-success">CPU: 0%</div>
-      <div id="bufferSize" class="alert alert-success" style="display:none">Buffer: 127</div>
-      <div id="controllerStatusAlert" class="alert alert-danger">Not Connected</div>
-      <button id="controllerStatusButton" style="display:none" type="button" class="btn btn-sm btn-danger" onclick="requestPage('fakeServo');">Not Connected</button>
-    </div>
-</nav>
-
 <body>
-  <section class="content">
-    <header>
-      {% block header %}{% endblock %}
-    </header>
+  <div class="d-flex flex-column h-100">
+    <nav class="navbar navbar-expand-lg navbar-light bg-light sticky-top" data-name="">
+      <a class="navbar-brand" href="#">WebControl</a>
+      <!--<button id="mobileClientStatus" class="btn btn-outline-danger my-2 my-sm-0" type="button"><i data-feather="alert-circle"></i></button>-->
+      <div id="mobileClientStatus" class="alert alert-danger alert-sm">
+        <i data-feather="alert-circle"></i>
+      </div>
+      <!--<div id="mobileClientActivity" class="alert alert-dark alert-circle alert-sm"></div>-->
+      <div id="mobileCPUUsage" class="alert alert-success alert-sm">0%</div>
+      <div id="mobileBufferSize" class="alert alert-success alert-sm" style="display: none">-</div>
+      <!--<button id="mobileControllerStatus" class="btn btn-outline-danger my-2 my-sm-0" type="button"><i data-feather="alert-circle"></i></button>-->
+      <div id="mobileControllerStatusAlert" style="display: none" class="alert alert-danger alert-sm">
+        <i data-feather="alert-circle"></i>
+      </div>
+      <button id="mobileControllerStatusButton" style="display: none" type="button" class="btn btn-sm btn-danger" onclick="requestPage('fakeServo');">
+        <i id="mobileControllerStatusButtonIcon" data-feather="check-circle"></i>
+      </button>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <ul class="navbar-nav mr-auto">
+          <li class="nav-item dropdown"><a class="nav-link dropdown-toggle" href="#" id="navbarDropdown1" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"> G-Code </a>
+            <div class="dropdown-menu" aria-labelledby="navbarDropdown1">
+              <a class="dropdown-item" href="#" onclick="requestPage('openGCode');">Open</a> <a class="dropdown-item" href="#" onclick="requestPage('saveGCode');">Save</a> <a class="dropdown-item" href="#" onclick="requestPage('uploadGCode');">Upload</a> <a class="dropdown-item" href="#"
+                onclick="action('clearGCode');">Clear GCode</a> <a class="dropdown-item" href="#" onclick="requestPage('editGCode');">View/Edit</a> <a class="dropdown-item" href="#" onclick="requestPage('sendGCode');">Send Custom GCode</a>
+              <!--<a class="dropdown-item" href="#" onclick="action('optimizeGCode');">Optimize GCode</a>-->
+            </div></li>
+          <li class="nav-item" id="actionsNavItem"><a class="nav-link" href="#" onclick="requestPage('actions');">Actions</a></li>
+          <li class="nav-item dropdown"><a class="nav-link dropdown-toggle" href="#" id="navbarDropdown2" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"> Settings </a>
+            <div class="dropdown-menu" aria-labelledby="navbarDropdown2">
+              <a class="dropdown-item" href="#" onclick="requestPage('maslowSettings');">Maslow Settings</a> <a class="dropdown-item" href="#" onclick="requestPage('advancedSettings');">Advanced Settings</a> <a class="dropdown-item" href="#" onclick="requestPage('webControlSettings');">WebControl
+                Settings</a> <a class="dropdown-item" href="#" onclick="requestPage('cameraSettings');">Camera Settings</a> <a class="dropdown-item" href="#" onclick="requestPage('gpioSettings');">GPIO Settings</a>
+            </div></li>
+          <li class="nav-item dropdown"><a class="nav-link dropdown-toggle" href="#" id="navbarDropdown3" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"> Boards </a>
+            <div class="dropdown-menu" aria-labelledby="navbarDropdown3">
+              <a class="dropdown-item" href="#" onclick="requestPage('openBoard');">Open Board</a> <a class="dropdown-item" href="#" onclick="requestPage('saveBoard');">Save Board</a> <a class="dropdown-item" href="#" onclick="requestPage('editBoard');">Create/Edit Board</a> <a class="dropdown-item"
+                href="#" onclick="requestPage('trimBoard');">Trim Board</a> <a class="dropdown-item" href="#" onclick="action('boardProcessGCode');">Process GCode</a> <a class="dropdown-item" href="#" onclick="action('boardClearBoard');">Clear Board</a>
+            </div></li>
+          <li class="nav-item dropdown"><span id="helpBadge" class="badge badge-pill badge-primary" style="float: left; margin-bottom: -10px;"></span> <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown4" role="button" data-toggle="dropdown" aria-haspopup="true"
+            aria-expanded="false"> Help </a>
+            <div class="dropdown-menu" aria-labelledby="navbarDropdown4">
+              <a class="dropdown-item" href="#" onclick="requestPage('gettingStarted');">Getting Started</a> <a class="dropdown-item" href="https://madgrizzle.github.io/WebControl/" target="_blank">Online Help</a> <a class="dropdown-item" href="#" onclick="requestPage('help');">Offline Help</a> <a
+                class="dropdown-item" href="#" onclick="requestPage('about');">About</a> <span id="updateBadge" class="badge badge-pill badge-primary" style="float: left; margin-bottom: -10px;"></span> <a class="dropdown-item" href="#" onclick="requestPage('releases');">Update</a> <a
+                class="dropdown-item" href="logs" target="_blank">Logs</a>
+            </div></li>
+        </ul>
+        <div id="clientStatus" class="alert alert-danger">Not Connect</div>
+        <!--<div id="activity" class="alert alert-success alert-circle alert-sm"></div>-->
+        <div id="cpuUsage" class="alert alert-success">CPU: 0%</div>
+        <div id="bufferSize" class="alert alert-success" style="display: none">Buffer: 127</div>
+        <div id="controllerStatusAlert" class="alert alert-danger">Not Connected</div>
+        <button id="controllerStatusButton" style="display: none" type="button" class="btn btn-sm btn-danger" onclick="requestPage('fakeServo');">Not Connected</button>
+      </div>
+    </nav>
+
+    <header> {% block header %}{% endblock %} </header>
     {% for message in get_flashed_messages() %}
-      <div class="flash">{{ message }}</div>
-    {% endfor %}
-    {% block content %}{% endblock %}
-  </section>
+    <div class="flash">{{ message }}</div>
+    {% endfor %} {% block content %}{% endblock %}
+  </div>
 
   <div class="modal" id="notificationModal" tabindex="-1" role="dialog">
     <div id="notificationDialog" class="modal-dialog {{modalStyle}}" role="document">
@@ -109,17 +79,15 @@
             <span aria-hidden="true">&times;</span>
           </button>
         </div>
-        <div id="notificationModalText" class="modal-body">
-        </div>
-        <div class="progress" id="progressBarDiv" >
+        <div id="notificationModalText" class="modal-body"></div>
+        <div class="progress" id="progressBarDiv">
           <div id="progressBar" class="progress-bar w-75" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
         </div>
         <div id="notificationCircle">
           <div class="loader">
             <div class="loader">
               <div class="loader">
-                <div class="loader">
-                </div>
+                <div class="loader"></div>
               </div>
             </div>
           </div>
@@ -133,8 +101,8 @@
     </div>
   </div>
 
-  <div class="modal" id="contentModal" tabindex="-1" role="dialog" >
-    <div id="contentDialog" class="modal-dialog {{modalStyle}}" role="document" >
+  <div class="modal" id="contentModal" tabindex="-1" role="dialog">
+    <div id="contentDialog" class="modal-dialog {{modalStyle}}" role="document">
       <div class="modal-content">
         <div class="modal-header">
           <h5 id="contentModalTitle" class="modal-title">Modal title</h5>
@@ -143,8 +111,7 @@
           </button>
         </div>
         <div class="modal-body">
-          <div id="contentModalText">
-          </div>
+          <div id="contentModalText"></div>
         </div>
         <div class="modal-footer">
           <button id="footerSubmit" type="button" class="btn btn-primary" onclick="onFooterSubmit();">Submit</button>
@@ -163,8 +130,7 @@
             <span aria-hidden="true">&times;</span>
           </button>
         </div>
-        <div id="alertModalText" class="modal-body">
-        </div>
+        <div id="alertModalText" class="modal-body"></div>
         <div class="modal-footer">
           <button id="clearButton" type="button" class="btn btn-info" onclick="action('stopRun')" data-dismiss="modal">Clear Alert</button>
           <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>

--- a/templates/frontpage3d.html
+++ b/templates/frontpage3d.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 
-{% block header %}
+{% block head %}
   <link rel="stylesheet" href="{{ url_for('static',filename='styles/frontpage.css', version='11102018j') }}" crossorigin="anonymous">
   <!--<style> #workarea {background-color: #AAA; width: 100%; height: 100%; border: 1px solid black;}</style>-->
 {% endblock %}

--- a/templates/frontpage3d.html
+++ b/templates/frontpage3d.html
@@ -24,9 +24,6 @@
   <div class="sidebar d-flex ml-3">
     <!--"col my-sidebar">-->
     <div class="flex-column d-flex flex-grow-1">
-      <div>
-        <h3>Controls</h3>
-      </div>
       <div class="controls row">
         <div class="col-3 mb-1">
           <button type="button" class="btn btn-secondary btn-block disabler" onclick="moveAction('upLeft')">
@@ -225,7 +222,7 @@
       </div>
       <div class="row">
         <div class="col mb-1">
-          <h3>Controller Messages</h3>
+          <h4>Controller Messages</h4>
         </div>
       </div>
       <div class="row flex-grow-1 position-relative">

--- a/templates/frontpage3d.html
+++ b/templates/frontpage3d.html
@@ -1,237 +1,270 @@
 {% extends 'base.html' %}
 
 {% block head %}
-  <link rel="stylesheet" href="{{ url_for('static',filename='styles/frontpage.css', version='11102018j') }}" crossorigin="anonymous">
-  <!--<style> #workarea {background-color: #AAA; width: 100%; height: 100%; border: 1px solid black;}</style>-->
+<link rel="stylesheet" href="{{ url_for('static',filename='styles/frontpage.css', version='11102018j') }}" crossorigin="anonymous">
+<!--<style> #workarea {background-color: #AAA; width: 100%; height: 100%; border: 1px solid black;}</style>-->
 {% endblock %}
 
 {% block javascript %}
-  <script>
-    enable3D=true;
-  </script>
-  <script src="{{ url_for('static',filename='scripts/pako.min.js') }}" crossorigin="anonymous"></script>
-  <script src="{{ url_for('static',filename='scripts/feather.min.js') }}" crossorigin="anonymous"></script>
-  <script src="{{ url_for('static',filename='scripts/three.js') }}" crossorigin="anonymous"></script>
-  <script src="{{ url_for('static',filename='scripts/orbitcontrols.js') }}" crossorigin="anonymous"></script>
-  <script src="{{ url_for('static',filename='scripts/sprite3D.js') }}" crossorigin="anonymous"></script>
-  <script src="{{ url_for('static',filename='scripts/frontpage3d.js', version='11102019v') }}" crossorigin="anonymous"></script>
-  <script src="{{ url_for('static',filename='scripts/frontpageControls.js', version='11102019t') }}" crossorigin="anonymous"></script>
-  <script> feather.replace() </script>
+<script>
+  enable3D = true;
+</script>
+<script src="{{ url_for('static',filename='scripts/pako.min.js') }}" crossorigin="anonymous"></script>
+<script src="{{ url_for('static',filename='scripts/feather.min.js') }}" crossorigin="anonymous"></script>
+<script src="{{ url_for('static',filename='scripts/three.js') }}" crossorigin="anonymous"></script>
+<script src="{{ url_for('static',filename='scripts/orbitcontrols.js') }}" crossorigin="anonymous"></script>
+<script src="{{ url_for('static',filename='scripts/sprite3D.js') }}" crossorigin="anonymous"></script>
+<script src="{{ url_for('static',filename='scripts/frontpage3d.js', version='11102019v') }}" crossorigin="anonymous"></script>
+<script src="{{ url_for('static',filename='scripts/frontpageControls.js', version='11102019t') }}" crossorigin="anonymous"></script>
+<script> feather.replace() </script>
 {% endblock %}
 
 {% block content %}
-<div class="container-fluid d-flex flex-row-reverse">
-    <div class="flex-fixed-width-item"><!--"col my-sidebar">-->
+<div class="container-fluid d-flex flex-row-reverse flex-grow-1">
+  <div class="sidebar d-flex ml-3">
+    <!--"col my-sidebar">-->
+    <div class="flex-column d-flex flex-grow-1">
+      <div>
         <h3>Controls</h3>
-        <div>
-        <div class="controls row">
-          <div class="col-3 mb-1">
-            <button type="button" class="btn btn-secondary btn-block disabler" onclick="moveAction('upLeft')"><i data-feather="arrow-up-left"></i></button>
-          </div>
-          <div class="col-3 mb-1">
-            <button type="button" class="btn btn-dark btn-block" onclick="moveAction('up')"><i data-feather="arrow-up"></i></button>
-          </div>
-          <div class="col-3 mb-1">
-            <button type="button" class="btn btn-secondary btn-block" onclick="moveAction('upRight')"><i data-feather="arrow-up-right"></i></button>
-          </div>
-          <div class="col-3 mb-1">
-            <button type="button" class="btn btn-primary btn-block" onclick="action('macro1')">{{ macro1_title }}</button>
-          </div>
-          <div class="w-100"></div>
-          <div class="col-3 mb-1">
-            <button type="button" class="btn btn-dark btn-block" onclick="moveAction('left')"><i data-feather="arrow-left"></i></button>
-          </div>
-          <div class="col-3 mb-1">
-            <button type="button" class="btn btn-dark btn-block" onclick="action('home')"><i data-feather="home"></i></button>
-          </div>
-          <div class="col-3 mb-1">
-            <button type="button" class="btn btn-dark btn-block" onclick="moveAction('right')"><i data-feather="arrow-right"></i></button>
-          </div>
-          <div class="col-3 mb-1">
-            <button type="button" class="btn btn-primary btn-block" onclick="action('macro2')">{{ macro2_title }}</button>
-          </div>
-          <div class="w-100"></div>
-          <div class="col-3 mb-1">
-            <button type="button" class="btn btn-secondary btn-block" onclick="moveAction('downLeft')"><i data-feather="arrow-down-left"></i></button>
-          </div>
-          <div class="col-3 mb-1">
-            <button type="button" class="btn btn-dark btn-block" onclick="moveAction('down')"><i data-feather="arrow-down"></i></button>
-          </div>
-          <div class="col-3 mb-1">
-            <button type="button" class="btn btn-secondary btn-block" onclick="moveAction('downRight')"><i data-feather="arrow-down-right"></i></button>
-          </div>
-          <div class="col-3 mb-1">
-            <button type="button" class="btn btn-primary btn-block" onclick="requestPage('zAxis');">ZAxis</button>
-          </div>
-          <div class="w-100"></div>
-          <div class="col-3 mb-1">
-            <label>Distance:</label>
-          </div>
-          <div class="col-3 mb-1">
-            <form id="distInput" onsubmit="return false;"><input class="form-control" type="text" pattern="^[0-9]*(\.[0-9]{0,3})?$" id="distToMove" title="Positive number with maximum 3 decimal places"></form>
-          </div>
-          <div class="col-3 mb-1">
-            <button id="units" type="button" class="btn btn-secondary" onclick="unitSwitch();">--</button>
-          </div>
-          <div class="col-3 mb-1">
-            <button id="btnDefHome" type="button" class="btn btn-primary btn-block" onclick="action('defineHome')" ><i data-feather="save">Def.</i> <i data-feather="home">Home</i></button>
+      </div>
+      <div class="controls row">
+        <div class="col-3 mb-1">
+          <button type="button" class="btn btn-secondary btn-block disabler" onclick="moveAction('upLeft')">
+            <i data-feather="arrow-up-left"></i>
+          </button>
+        </div>
+        <div class="col-3 mb-1">
+          <button type="button" class="btn btn-dark btn-block" onclick="moveAction('up')">
+            <i data-feather="arrow-up"></i>
+          </button>
+        </div>
+        <div class="col-3 mb-1">
+          <button type="button" class="btn btn-secondary btn-block" onclick="moveAction('upRight')">
+            <i data-feather="arrow-up-right"></i>
+          </button>
+        </div>
+        <div class="col-3 mb-1">
+          <button type="button" class="btn btn-primary btn-block" onclick="action('macro1')">{{ macro1_title }}</button>
+        </div>
+        <div class="w-100"></div>
+        <div class="col-3 mb-1">
+          <button type="button" class="btn btn-dark btn-block" onclick="moveAction('left')">
+            <i data-feather="arrow-left"></i>
+          </button>
+        </div>
+        <div class="col-3 mb-1">
+          <button type="button" class="btn btn-dark btn-block" onclick="action('home')">
+            <i data-feather="home"></i>
+          </button>
+        </div>
+        <div class="col-3 mb-1">
+          <button type="button" class="btn btn-dark btn-block" onclick="moveAction('right')">
+            <i data-feather="arrow-right"></i>
+          </button>
+        </div>
+        <div class="col-3 mb-1">
+          <button type="button" class="btn btn-primary btn-block" onclick="action('macro2')">{{ macro2_title }}</button>
+        </div>
+        <div class="w-100"></div>
+        <div class="col-3 mb-1">
+          <button type="button" class="btn btn-secondary btn-block" onclick="moveAction('downLeft')">
+            <i data-feather="arrow-down-left"></i>
+          </button>
+        </div>
+        <div class="col-3 mb-1">
+          <button type="button" class="btn btn-dark btn-block" onclick="moveAction('down')">
+            <i data-feather="arrow-down"></i>
+          </button>
+        </div>
+        <div class="col-3 mb-1">
+          <button type="button" class="btn btn-secondary btn-block" onclick="moveAction('downRight')">
+            <i data-feather="arrow-down-right"></i>
+          </button>
+        </div>
+        <div class="col-3 mb-1">
+          <button type="button" class="btn btn-primary btn-block" onclick="requestPage('zAxis');">ZAxis</button>
+        </div>
+        <div class="w-100"></div>
+        <div class="col-3 mb-1">
+          <label>Distance:</label>
+        </div>
+        <div class="col-3 mb-1">
+          <form id="distInput" onsubmit="return false;">
+            <input class="form-control" type="text" pattern="^[0-9]*(\.[0-9]{0,3})?$" id="distToMove" title="Positive number with maximum 3 decimal places">
+          </form>
+        </div>
+        <div class="col-3 mb-1">
+          <button id="units" type="button" class="btn btn-secondary" onclick="unitSwitch();">--</button>
+        </div>
+        <div class="col-3 mb-1">
+          <button id="btnDefHome" type="button" class="btn btn-primary btn-block" onclick="action('defineHome')">
+            <i data-feather="save">Def.</i> <i data-feather="home">Home</i>
+          </button>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col mb-1">
+          <div id="alarms" class="alert alert-success alert-dismissible col-md-12">No alarms</div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col mb-1">
+          <button type="button" class="btn btn-block btn-success" onclick="action('startRun')">Play</button>
+        </div>
+        <div class="col mb-1">
+          <button type="button" id="pauseButton" class="btn btn-block btn-warning" onclick="pauseRun()">Pause</button>
+        </div>
+        <div class="col mb-1">
+          <button type="button" id="stopButton" class="btn btn-block btn-danger" onclick="$(this).removeClass('stopbutton'); action('stopRun')">Stop</button>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col mb-1">
+          <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeZ',-1);">&lt;Z</button>
+        </div>
+        <div class="col mb-1">
+          <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeIndex',-1);">&lt;1</button>
+        </div>
+        <div class="col mb-1">
+          <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeIndex',1);">1&gt;</button>
+        </div>
+        <div class="col mb-1">
+          <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeZ',1);">Z&gt;</button>
+        </div>
+      </div>
+      <div class="row align-items-center">
+        <div class="col-3 mb-1">
+          <h5>Line #:</h5>
+        </div>
+        <div class="col-4 mb-1">
+          <input class="form-control" type="number" step="1" id="gcodeLineIndex" value="1">
+        </div>
+        <div class="col-3 mb-1">
+          <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeGoto',$('#gcodeLineIndex').val()-1);">Goto</button>
+        </div>
+        <div class="col-2 mb-1">
+          <button id="videoStatus" type="button" class="btn btn-block btn-secondary" onclick="action('toggleCamera');">
+            <i data-feather="video-off"></i>
+          </button>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-3 mb-1">
+          <h5>Line:</h5>
+        </div>
+        <div class="col-9 mb-1">
+          <div class="text-nowrap" id='gcodeLine'></div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-3">
+          <h5>Sled:</h5>
+        </div>
+        <div class="col-9">
+          <div id='positionMessage'></div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-3">
+          <h5>Error:</h5>
+        </div>
+        <div class="col-4">
+          <div class="progress">
+            <div id="leftError" class="progress-bar" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
           </div>
         </div>
-        <div class="row">
-          <div class="col mb-1">
-            <div id="alarms" class="alert alert-success alert-dismissible col-md-12">No alarms</div>
+        <div class="col-4">
+          <div class="progress">
+            <div id="rightError" class="progress-bar" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
           </div>
         </div>
-        <div class="row">
-          <div class="col mb-1">
-            <button type="button" class="btn btn-block btn-success" onclick="action('startRun')">Play</button>
-          </div>
-          <div class="col mb-1">
-            <button type="button" id="pauseButton" class="btn btn-block btn-warning" onclick="pauseRun()">Pause</button>
-          </div>
-          <div class="col mb-1">
-            <button type="button" id="stopButton" class="btn btn-block btn-danger" onclick="$(this).removeClass('stopbutton'); action('stopRun')">Stop</button>
-          </div>
+      </div>
+      <div class="row">
+        <div class="col-3 mb-1">
+          <h5>Home:</h5>
         </div>
-        <div class="row">
-          <div class="col mb-1">
-            <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeZ',-1);">&lt;Z</button>
-          </div>
-          <div class="col mb-1">
-            <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeIndex',-1);">&lt;1</button>
-          </div>
-          <div class="col mb-1">
-            <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeIndex',1);">1&gt;</button>
-          </div>
-          <div class="col mb-1">
-            <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeZ',1);">Z&gt;</button>
-          </div>
+        <div class="col-9 mb-1">
+          <div id='homePositionMessage'></div>
         </div>
-        <div class="row align-items-center">
-          <div class="col-3 mb-1">
-            <h5>Line #:</h5>
-          </div>
-          <div class="col-4 mb-1">
-            <input class="form-control" type="number" step="1" id="gcodeLineIndex" value="1">
-          </div>
-          <div class="col-3 mb-1">
-            <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeGoto',$('#gcodeLineIndex').val()-1);">Goto</button>
-          </div>
-          <div class="col-2 mb-1">
-            <button id="videoStatus" type="button" class="btn btn-block btn-secondary" onclick="action('toggleCamera');"><i data-feather="video-off"></i></button>
-          </div>
+      </div>
+      <div class="row">
+        <div class="col-3 mb-1">
+          <h5>GCode:</h5>
         </div>
-        <div class="row">
-          <div class="col-3 mb-1">
-            <h5>Line:</h5>
-          </div>
-          <div class="col-9 mb-1">
-            <div class="text-nowrap" id='gcodeLine'></div>
-          </div>
+        <div class="col-9 mb-1">
+          <div id='gcodePositionMessage'></div>
         </div>
-        <div class="row">
-          <div class="col-3">
-            <h5>Sled:</h5>
-          </div>
-          <div class="col-9">
-            <div id='positionMessage'></div>
-          </div>
+      </div>
+      <div class="row">
+        <div class="col-3 mb-1">
+          <h5>Complete:</h5>
         </div>
-        <div class="row">
-          <div class="col-3">
-            <h5>Error:</h5>
-          </div>
-          <div class="col-4">
-            <div class="progress">
-              <div id="leftError" class = "progress-bar" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
-            </div>
-          </div>
-          <div class="col-4">
-            <div class="progress">
-              <div id="rightError" class = "progress-bar" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
-            </div>
-          </div>
-
+        <div class="col-3 mb-1">
+          <div id='percentComplete'></div>
         </div>
-        <div class="row">
-          <div class="col-3 mb-1">
-            <h5>Home:</h5>
-          </div>
-          <div class="col-9 mb-1">
-            <div id='homePositionMessage'></div>
-          </div>
+        <div class="col-3 mb-1">
+          <h5>State:</h5>
         </div>
-        <div class="row">
-          <div class="col-3 mb-1">
-            <h5>GCode:</h5>
-          </div>
-          <div class="col-9 mb-1">
-            <div id='gcodePositionMessage'></div>
-          </div>
+        <div class="col-3 mb-1">
+          <div id='machineState'></div>
         </div>
-        <div class="row">
-          <div class="col-3 mb-1">
-            <h5>Complete:</h5>
-          </div>
-          <div class="col-3 mb-1">
-            <div id='percentComplete'></div>
-          </div>
-          <div class="col-3 mb-1">
-            <h5>State:</h5>
-          </div>
-          <div class="col-3 mb-1">
-            <div id='machineState'></div>
-          </div>
+      </div>
+      <div class="row">
+        <div class="col-2 mb-1">
+          <h5>Tool:</h5>
         </div>
-        <div class="row">
-          <div class="col-2 mb-1">
-            <h5>Tool:</h5>
-          </div>
-          <div class="col-1 mb-1">
-            <div id='currentTool'></div>
-          </div>
-          <div class="col-4 mb-1">
-            <h5>Positioning:</h5>
-          </div>
-          <div class="col-5 mb-1">
-            <div id='currentPositioningMode'></div>
-          </div>
+        <div class="col-1 mb-1">
+          <div id='currentTool'></div>
         </div>
-        <div class="row">
-          <div class="col mb-1">
-            <h3>Controller Messages</h3>
-          </div>
+        <div class="col-4 mb-1">
+          <h5>Positioning:</h5>
         </div>
+        <div class="col-5 mb-1">
+          <div id='currentPositioningMode'></div>
         </div>
-        <div class="scrollText w-100" id='controllerMessage'></div>
+      </div>
+      <div class="row">
+        <div class="col mb-1">
+          <h3>Controller Messages</h3>
+        </div>
+      </div>
+      <div class="row flex-grow-1 position-relative">
+        <div class="scrollText ml-3" id='controllerMessage'></div>
+      </div>
     </div>
-    <div id="workarea" class="flex-grow-1 fullWorkArea"> <!--class="col">-->
-        <!--<div id="button3DResetGroup" class="btn-group" role="group">
+  </div>
+  <div id="workarea" class="flex-column flex-grow-1 fullWorkArea">
+    <!--class="col">-->
+    <!--<div id="button3DResetGroup" class="btn-group" role="group">
             <button class="btn btn-secondary btn-sm" type="button" id="button3D" onclick="toggle3DView()">3D</button>
             <button class="btn btn-secondary btn-sm" type="button" id="buttonReset" onclick="resetView()">Reset</button>
             <div id="cursorPosition" class="alert alert-success alert-dismissible">Cursor Position</div>
         </div>-->
-        <div id="button3DResetGroup"><!-- class="btn-toolbar" role="toolbar">-->
-            <button class="btn btn-secondary btn-sm" type="button" id="button3D" onclick="toggle3DView()">3D</button>
-            <button class="btn btn-secondary btn-sm" type="button" id="buttonPO" onclick="toggle3DPO()">Ortho</button>
-            <button class="btn btn-secondary btn-sm" type="button" id="buttonReset" onclick="resetView()">Reset</button>
-            <!--<button class="btn btn-secondary btn-sm" type="button" id="cursorPosition">Cursor Position</button>-->
-            <span id="cursorPosition" class="btn btn-secondary btn-sm">Cursor Position</span>
-            <button id="boardID" class="btn btn-secondary btn-sm" onclick="toggleBoard()">...</button>
-            <button id="labelsID" class="btn btn-secondary btn-sm" onclick="toggleLabels()">Labels</button>
-        </div>
-      <div id="cameraDiv1"><img id="cameraImage1" src="#" style="display:none"></div>
-      <div id="cameraDiv2"><img id="cameraImage2" src="#" style="display:none"></div>
+    <div id="button3DResetGroup">
+      <!-- class="btn-toolbar" role="toolbar">-->
+      <button class="btn btn-secondary btn-sm" type="button" id="button3D" onclick="toggle3DView()">3D</button>
+      <button class="btn btn-secondary btn-sm" type="button" id="buttonPO" onclick="toggle3DPO()">Ortho</button>
+      <button class="btn btn-secondary btn-sm" type="button" id="buttonReset" onclick="resetView()">Reset</button>
+      <!--<button class="btn btn-secondary btn-sm" type="button" id="cursorPosition">Cursor Position</button>-->
+      <span id="cursorPosition" class="btn btn-secondary btn-sm">Cursor Position</span>
+      <button id="boardID" class="btn btn-secondary btn-sm" onclick="toggleBoard()">...</button>
+      <button id="labelsID" class="btn btn-secondary btn-sm" onclick="toggleLabels()">Labels</button>
     </div>
-    <div id="fpCircle" style="display: none;">
+    <div id="cameraDiv1">
+      <img id="cameraImage1" src="#" style="display: none">
+    </div>
+    <div id="cameraDiv2">
+      <img id="cameraImage2" src="#" style="display: none">
+    </div>
+  </div>
+  <div id="fpCircle" style="display: none;">
+    <div class="loader">
       <div class="loader">
         <div class="loader">
-          <div class="loader">
-            <div class="loader">
-            </div>
-          </div>
+          <div class="loader"></div>
         </div>
       </div>
     </div>
+  </div>
 </div>
 {% endblock %}

--- a/templates/frontpage3d.html
+++ b/templates/frontpage3d.html
@@ -115,10 +115,10 @@
             <input class="form-control" type="number" step="1" id="gcodeLineIndex" value="1">
           </div>
           <div class="col-3 mb-1">
-            <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeGoto',$('#gcodeLineIndex').val()-1);")>Goto</button>
+            <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeGoto',$('#gcodeLineIndex').val()-1);">Goto</button>
           </div>
           <div class="col-2 mb-1">
-            <button id="videoStatus" type="button" class="btn btn-block btn-secondary" onclick="action('toggleCamera');")><i data-feather="video-off"></i></button>
+            <button id="videoStatus" type="button" class="btn btn-block btn-secondary" onclick="action('toggleCamera');"><i data-feather="video-off"></i></button>
           </div>
         </div>
         <div class="row">

--- a/templates/frontpage3d_mobile.html
+++ b/templates/frontpage3d_mobile.html
@@ -1,5 +1,4 @@
 {% extends 'base.html' %}
-
 {% block head %}
   <link rel="stylesheet" href="{{ url_for('static',filename='styles/frontpage.css', version='10262019a') }}" crossorigin="anonymous">
 {% endblock %}
@@ -75,10 +74,10 @@
     </div>
     <div class="row">
       <div class="col-4  mb-1">
-        <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('macro1')" >Macro1</button>
+        <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('macro1')">Macro1</button>
       </div>
       <div class="col-4  mb-1">
-        <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('macro2')" >Macro2</button>
+        <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('macro2')">Macro2</button>
       </div>
       <div class="col-4  mb-1">
         <button type="button" class="btn btn-lg btn-primary btn-block" onclick="requestPage('zAxis')">ZAxis</button>
@@ -86,14 +85,17 @@
     </div>
     <div class="row">
       <div class="col-4  mb-1">
-        <form onsubmit="return false;"><input class="form-control" type="text" inputmode="decimal" pattern="^[0-9]*(\.[0-9]{0,3})?$" id="distToMove" title="Positive number with maximum 3 decimal places"></form>
+        <form onsubmit="return false;">
+          <input class="form-control" type="text" inputmode="decimal" pattern="^[0-9]*(\.[0-9]{0,3})?$" id="distToMove" title="Positive number with maximum 3 decimal places">
+        </form>
       </div>
       <div class="col-4  mb-1">
         <button id="units" type="button" class="btn btn-lg btn-secondary" onclick="unitSwitch()">--</button>
       </div>
       <div class="col-4  mb-1">
-        <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('defineHome')" >
-        <i data-feather="save">Def.</i> <i data-feather="home">Home</i></button>
+        <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('defineHome')">
+          <i data-feather="save">Def.</i> <i data-feather="home">Home</i>
+        </button>
       </div>
     </div>
   </div>
@@ -128,26 +130,26 @@
       <button type="button" class="btn btn-md btn-block btn-secondary" onclick="action('moveGcodeZ',1);">Z&gt;</button>
     </div>
   </div>
-  
+
   <div class="row align-items-center">
-      <div class="col-4 mb-1">
-        <h5>Line #:</h5>
-      </div>
-      <div class="col-4 mb-1">
-        <input class="form-control" type="number" step="1"  id="gcodeLineIndex" value="1">
-      </div>
-      <div class="col-4 mb-1">
-        <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeGoto',$('#gcodeLineIndex').val()-1)">Goto</button>
-      </div>
+    <div class="col-4 mb-1">
+      <h5>Line #:</h5>
+    </div>
+    <div class="col-4 mb-1">
+      <input class="form-control" type="number" step="1" id="gcodeLineIndex" value="1">
+    </div>
+    <div class="col-4 mb-1">
+      <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeGoto',$('#gcodeLineIndex').val()-1)">Goto</button>
+    </div>
   </div>
   <div class="row">
-      <div class="col-3 mb-1">
-        <h5>Line:</h5>
-      </div>
-      <div class="col-9 mb-1">
-        <div id='gcodeLine'></div>
-      </div>
-  </div>  
+    <div class="col-3 mb-1">
+      <h5>Line:</h5>
+    </div>
+    <div class="col-9 mb-1">
+      <div id='gcodeLine'></div>
+    </div>
+  </div>
   <div class="row">
     <div class="col-3  mb-1">
       <h5>Position:</h5>
@@ -162,12 +164,12 @@
     </div>
     <div class="col-4">
       <div class="progress">
-        <div id="leftError" class = "progress-bar" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+        <div id="leftError" class="progress-bar" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
       </div>
     </div>
     <div class="col-4">
       <div class="progress">
-        <div id="rightError" class = "progress-bar" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+        <div id="rightError" class="progress-bar" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
       </div>
     </div>
   </div>
@@ -223,25 +225,30 @@
     <button id="boardID" class="btn btn-primary btn-block" onclick="toggleBoard()">...</button>
   </div>
   <div class="card">
-    <div class = "card-body">
-      <div id="workarea" style="height:400px"></div>
+    <div class="card-body">
+      <div id="workarea" style="height: 400px"></div>
     </div>
   </div>
   <div class="col-3 mb-1">
-    <button id="videoStatus" type="button" class="btn btn-block btn-secondary" onclick="action('toggleCamera')"><i data-feather="video-off"></i></button>
+    <button id="videoStatus" type="button" class="btn btn-block btn-secondary" onclick="action('toggleCamera')">
+      <i data-feather="video-off"></i>
+    </button>
   </div>
-  <div id="mobileCameraArea" class="row" style="height:200px" style="display:none">
+  <div id="mobileCameraArea" class="row" style="height: 200px" style="display:none">
     <div class="col">
-        <div id="mobileCameraDiv1"><img id="cameraImage1" src="#" style="display:none"></div>
-        <div id="mobileCameraDiv2"><img id="cameraImage2" src="#" style="display:none"></div>
+      <div id="mobileCameraDiv1">
+        <img id="cameraImage1" src="#" style="display: none">
+      </div>
+      <div id="mobileCameraDiv2">
+        <img id="cameraImage2" src="#" style="display: none">
+      </div>
     </div>
   </div>
   <div id="fpCircle" style="display: none;">
     <div class="loader">
       <div class="loader">
         <div class="loader">
-          <div class="loader">
-          </div>
+          <div class="loader"></div>
         </div>
       </div>
     </div>

--- a/templates/frontpage3d_mobile.html
+++ b/templates/frontpage3d_mobile.html
@@ -1,7 +1,10 @@
 {% extends 'base.html' %}
 
-{% block header %}
+{% block head %}
   <link rel="stylesheet" href="{{ url_for('static',filename='styles/frontpage.css', version='10262019a') }}" crossorigin="anonymous">
+{% endblock %}
+
+{% block header %}
   <meta name="viewport" content="width=device-width, initial-scale=1">
 {% endblock %}
 

--- a/templates/frontpage3d_mobilecontrols.html
+++ b/templates/frontpage3d_mobilecontrols.html
@@ -1,14 +1,17 @@
 {% extends 'base.html' %}
 
-{% block header %}
+{% block head %}
   <link rel="stylesheet" href="{{ url_for('static',filename='styles/frontpage.css', version='10262019b') }}" crossorigin="anonymous">
+{% endblock %}
+
+{% block header %}
   <meta name="viewport" content="width=device-width, initial-scale=1">
 {% endblock %}
 
 {% block javascript %}
   <script src="{{ url_for('static',filename='scripts/feather.min.js') }}" crossorigin="anonymous"></script>
   <script src="{{ url_for('static',filename='scripts/frontpage3dcontrols.js', version='11102018t') }}" crossorigin="anonymous"></script>
-<script> feather.replace() </script>
+  <script> feather.replace() </script>
 {% endblock %}
 
 {% block content %}

--- a/templates/frontpage3d_mobilecontrols.html
+++ b/templates/frontpage3d_mobilecontrols.html
@@ -70,10 +70,10 @@
   </div>
   <div class="row">
     <div class="col-4  mb-1">
-      <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('macro1')" >{{ macro1_title }}</button>
+      <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('macro1')">{{ macro1_title }}</button>
     </div>
     <div class="col-4  mb-1">
-      <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('macro2')" >{{ macro2_title }}</button>
+      <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('macro2')">{{ macro2_title }}</button>
     </div>
     <div class="col-4  mb-1">
       <button type="button" class="btn btn-lg btn-primary btn-block" onclick="requestPage('zAxis');">ZAxis</button>
@@ -81,7 +81,7 @@
   </div>
   <div class="row">
     <div class="col-5  mb-1">
-      <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('defineHome')" >Def. Home</button>
+      <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('defineHome')">Def. Home</button>
     </div>
   </div>
   <div class="row">
@@ -128,23 +128,23 @@
   </div>
 
   <div class="row align-items-center">
-      <div class="col-3 mb-1">
-        <h5>Line #:</h5>
-      </div>
-      <div class="col-4 mb-1">
-        <input class="form-control" type="number" step="1"  id="gcodeLineIndex" value="1">
-      </div>
-      <div class="col-3 mb-1">
-        <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeGoto',$('#gcodeLineIndex').val()-1);">Goto</button>
-      </div>
+    <div class="col-3 mb-1">
+      <h5>Line #:</h5>
+    </div>
+    <div class="col-4 mb-1">
+      <input class="form-control" type="number" step="1" id="gcodeLineIndex" value="1">
+    </div>
+    <div class="col-3 mb-1">
+      <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeGoto',$('#gcodeLineIndex').val()-1);">Goto</button>
+    </div>
   </div>
   <div class="row">
-      <div class="col-3 mb-1">
-        <h5>Line:</h5>
-      </div>
-      <div class="col-9 mb-1">
-        <div id='gcodeLine'></div>
-      </div>
+    <div class="col-3 mb-1">
+      <h5>Line:</h5>
+    </div>
+    <div class="col-9 mb-1">
+      <div id='gcodeLine'></div>
+    </div>
   </div>
   <div class="row">
     <div class="col-3  mb-1">
@@ -160,12 +160,12 @@
     </div>
     <div class="col-4">
       <div class="progress">
-        <div id="leftError" class = "progress-bar" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+        <div id="leftError" class="progress-bar" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
       </div>
     </div>
     <div class="col-4">
       <div class="progress">
-        <div id="rightError" class = "progress-bar" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+        <div id="rightError" class="progress-bar" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
       </div>
     </div>
   </div>
@@ -209,21 +209,19 @@
     <div class="loader">
       <div class="loader">
         <div class="loader">
-          <div class="loader">
-          </div>
+          <div class="loader"></div>
         </div>
       </div>
     </div>
   </div>
   <div class="row">
-      <div class="col mb-1">
-        <h3>Controller Messages</h3>
-      </div>
+    <div class="col mb-1">
+      <h3>Controller Messages</h3>
     </div>
-    <div class="row">
-      <div class="col mb-1">
-        <div class="scrollTextMobile" id='controllerMessage'></div>
-      </div>
+  </div>
+  <div class="row">
+    <div class="col mb-1">
+      <div class="scrollTextMobile" id='controllerMessage'></div>
     </div>
   </div>
 </div>

--- a/templates/frontpage3d_mobilecontrols.html
+++ b/templates/frontpage3d_mobilecontrols.html
@@ -24,7 +24,7 @@
       </button>
     </div>
     <div class="col-4  mb-1">
-      <button type="button" class="btn btn-lg btn-dark btn-block" onclick="action('move','up',$('#distToMove').val())";>
+      <button type="button" class="btn btn-lg btn-dark btn-block" onclick="action('move','up',$('#distToMove').val())">
         <i data-feather="arrow-up"></i>
       </button>
     </div>
@@ -135,7 +135,7 @@
         <input class="form-control" type="number" step="1"  id="gcodeLineIndex" value="1">
       </div>
       <div class="col-3 mb-1">
-        <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeGoto',$('#gcodeLineIndex').val()-1);")>Goto</button>
+        <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeGoto',$('#gcodeLineIndex').val()-1);">Goto</button>
       </div>
   </div>
   <div class="row">

--- a/templates/frontpageText.html
+++ b/templates/frontpageText.html
@@ -11,7 +11,7 @@
   </script>
   <script src="{{ url_for('static',filename='scripts/feather.min.js') }}" crossorigin="anonymous"></script>
   <script src="{{ url_for('static',filename='scripts/frontpageControls.js', version='11102018t') }}" crossorigin="anonymous"></script>
-<script> feather.replace() </script>
+  <script> feather.replace() </script>
 {% endblock %}
 
 {% block content %}
@@ -24,7 +24,7 @@
       </button>
     </div>
     <div class="col-4  mb-1">
-      <button type="button" class="btn btn-lg btn-dark btn-block" onclick="action('move','up',$('#distToMove').val())";>
+      <button type="button" class="btn btn-lg btn-dark btn-block" onclick="action('move','up',$('#distToMove').val())">
         <i data-feather="arrow-up"></i>
       </button>
     </div>
@@ -70,10 +70,10 @@
   </div>
   <div class="row">
     <div class="col-4  mb-1">
-      <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('macro1')" >{{ macro1_title }}</button>
+      <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('macro1')">{{ macro1_title }}</button>
     </div>
     <div class="col-4  mb-1">
-      <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('macro2')" >{{ macro2_title }}</button>
+      <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('macro2')">{{ macro2_title }}</button>
     </div>
     <div class="col-4  mb-1">
       <button type="button" class="btn btn-lg btn-primary btn-block" onclick="requestPage('zAxis');">ZAxis</button>
@@ -81,7 +81,7 @@
   </div>
   <div class="row">
     <div class="col-5  mb-1">
-      <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('defineHome')" >Def. Home</button>
+      <button type="button" class="btn btn-lg btn-primary btn-block" onclick="action('defineHome')">Def. Home</button>
     </div>
   </div>
   <div class="row">
@@ -128,23 +128,23 @@
   </div>
 
   <div class="row align-items-center">
-      <div class="col-3 mb-1">
-        <h5>Line #:</h5>
-      </div>
-      <div class="col-4 mb-1">
-        <input class="form-control" type="number" step="1"  id="gcodeLineIndex" value="1">
-      </div>
-      <div class="col-3 mb-1">
-        <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeGoto',$('#gcodeLineIndex').val()-1);">Goto</button>
-      </div>
+    <div class="col-3 mb-1">
+      <h5>Line #:</h5>
+    </div>
+    <div class="col-4 mb-1">
+      <input class="form-control" type="number" step="1" id="gcodeLineIndex" value="1">
+    </div>
+    <div class="col-3 mb-1">
+      <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeGoto',$('#gcodeLineIndex').val()-1);">Goto</button>
+    </div>
   </div>
   <div class="row">
-      <div class="col-3 mb-1">
-        <h5>Line:</h5>
-      </div>
-      <div class="col-9 mb-1">
-        <div id='gcodeLine'></div>
-      </div>
+    <div class="col-3 mb-1">
+      <h5>Line:</h5>
+    </div>
+    <div class="col-9 mb-1">
+      <div id='gcodeLine'></div>
+    </div>
   </div>
   <div class="row">
     <div class="col-3  mb-1">
@@ -160,12 +160,12 @@
     </div>
     <div class="col-4">
       <div class="progress">
-        <div id="leftError" class = "progress-bar" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+        <div id="leftError" class="progress-bar" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
       </div>
     </div>
     <div class="col-4">
       <div class="progress">
-        <div id="rightError" class = "progress-bar" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+        <div id="rightError" class="progress-bar" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
       </div>
     </div>
   </div>
@@ -209,21 +209,19 @@
     <div class="loader">
       <div class="loader">
         <div class="loader">
-          <div class="loader">
-          </div>
+          <div class="loader"></div>
         </div>
       </div>
     </div>
   </div>
   <div class="row">
-      <div class="col mb-1">
-        <h3>Controller Messages</h3>
-      </div>
+    <div class="col mb-1">
+      <h3>Controller Messages</h3>
     </div>
-    <div class="row">
-      <div class="col mb-1">
-        <div class="scrollTextMobile" id='controllerMessage'></div>
-      </div>
+  </div>
+  <div class="row">
+    <div class="col mb-1">
+      <div class="scrollTextMobile" id='controllerMessage'></div>
     </div>
   </div>
 </div>

--- a/templates/frontpageText.html
+++ b/templates/frontpageText.html
@@ -135,7 +135,7 @@
         <input class="form-control" type="number" step="1"  id="gcodeLineIndex" value="1">
       </div>
       <div class="col-3 mb-1">
-        <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeGoto',$('#gcodeLineIndex').val()-1);")>Goto</button>
+        <button type="button" class="btn btn-block btn-secondary" onclick="action('moveGcodeGoto',$('#gcodeLineIndex').val()-1);">Goto</button>
       </div>
   </div>
   <div class="row">


### PR DESCRIPTION
Well this turned out to be a lot more work then I expected and took almost a solid day. 

I have split it out into many commits to make it easier to see what has changed as there are a few source code formatting commits. The main changes are for desktop layout only, with minor fixes for mobile.

## Bootstrap Layout:

- The whole layout is now fully fluid using flexbox and grows/shrinks correctly on resize and zoom.
- Navigation is now in `<body>` and part of the layout so no need for offset padding. 
- Removed all `calc()` from CSS that used fixed pixel sizes that did not work properly.
- Fixed margins on sidebar which sometimes did not work.
- Layout fits browser window without scrollbars! 
- Controller Message scroll box has minimum height so it is always visible (previously not) but otherwise grows to fit bottom right corner. This took a while to figure out.
- The render canvas now shrinks when browser is made smaller. Made possible by temporarily making it 10x10px, then measuring parent div, then resizing canvas.  

## Jijna templates:
- Move all JavaScript to just before `</body>` which is optimal place for loading.
- Created `{% Head %}` template block in HTML `<head>` for additional CSS files. Move CSS files that were in `{% Header %}` to be in `{% Head %}`.

## Template HTML:
- Fix erroneous characters in button tags
- Remove extra `</div>` that was in a number of frontpage* files. Had to format source code and compare to see where the extra tag came from.
- Removed 'Controls' heading and made 'Controller Message' message smaller to get 4 extra line for messages on a 1080P screen.

## Testing:
- Checked all modals, menu, and loading animation. Nothing else should really be affected.
- Be sure to clear JS and CSS caches! 

## ToDo:
- The caching of JS and CSS does not work properly as the files are not reloaded when they change. I think this is because of the version numbers passed as variables in the URL. Any input on this or should I have a look at it?
- The Canvas resize uses a 10px offset in height becuase `#workarea` seems to be reporting a size slightly too bid. I cannot anything in CSS that is causing this. If you have any ideas let me know. This temp fix is causing the white padding at bottom of `#workarea`. 

## Merge Fix:
Noticed this will not cleanly merge due to changes in past two days to master. Let me know if you want me to merge master in to my fork.  

## Screenshot After:
![WebControl_Layout_Fluid](https://user-images.githubusercontent.com/7369439/77212054-0992bd00-6ac3-11ea-8517-706f592191bf.png)

