### PR TITLE
Fix M3 with no spindle speed.

### DIFF
--- a/File/gcodeFile.py
+++ b/File/gcodeFile.py
@@ -338,14 +338,14 @@ class GCodeFile(MakesmithInitFuncs):
         self.line3D[-1].dashed = False
 
     def getSpindleSpeed(self, mString):
-        code = mString[mString.find("S")+1:]
-        try:
-            if code!="":
-                return float(code)
-            else:
-                return 0
-        except:
-            return -1
+        sPos = mString.find("S")
+        speed = ""
+        if sPos != -1:
+            speed = mString[sPos+1:]
+        if speed != "":
+            return float(speed)
+        else:
+            return 0
 
     def getToolNumber(self, mString):
         code0 = mString.find("T")


### PR DESCRIPTION
Previous code ` mString[mString.find("S")+1:]` was return full _mString_  because find was returning _-1_ (when no spindle speed was found), to which 1 was added, and became 0.

This adds a few more checks.