### PR TITLE
Rpi off menu button

### DIFF
--- a/WebPageProcessor/webPageProcessor.py
+++ b/WebPageProcessor/webPageProcessor.py
@@ -247,15 +247,19 @@ class WebPageProcessor:
                 enableHoley = True
             if self.data.platform == "RPI":
                 docker = True
+                enableRPIshutdown = True
+                #print("RPI shutdown is TRUE")
             else:
                 docker = False
+                enableRPIshutdown = False
+                #print ("RPI shutdown is FALSE")
             if self.data.pyInstallUpdateAvailable:
                 updateAvailable = True
                 updateRelease = self.data.pyInstallUpdateVersion
             else:
                 updateAvailable = False
                 updateRelease = "N/A"
-            page = render_template("actions.html", updateAvailable=updateAvailable, updateRelease=updateRelease, docker=docker, customFirmwareVersion=self.data.customFirmwareVersion, stockFirmwareVersion=self.data.stockFirmwareVersion, holeyFirmwareVersion=self.data.holeyFirmwareVersion, enableCustom=enableCustom, enableHoley=enableHoley)
+            page = render_template("actions.html", updateAvailable=updateAvailable, updateRelease=updateRelease, docker=docker, customFirmwareVersion=self.data.customFirmwareVersion, stockFirmwareVersion=self.data.stockFirmwareVersion, holeyFirmwareVersion=self.data.holeyFirmwareVersion, enableCustom=enableCustom, enableHoley=enableHoley, enableRPIshutdown = enableRPIshutdown)
             return page, "Actions", False, "large", "content", False
         elif pageID == "zAxis":
             socketio.emit("closeModals", {"data": {"title": "Actions"}}, namespace="/MaslowCNC")

--- a/WebPageProcessor/webPageProcessor.py
+++ b/WebPageProcessor/webPageProcessor.py
@@ -245,7 +245,7 @@ class WebPageProcessor:
                 enableHoley = False
             else:
                 enableHoley = True
-            if self.data.platform == "RPI":
+            if ((self.data.platform == "RPI")or(self.data.platform == "PYINSTALLER")):
                 docker = True
                 enableRPIshutdown = True
                 #print("RPI shutdown is TRUE")

--- a/main.py
+++ b/main.py
@@ -687,7 +687,9 @@ def command(msg):
         print("Shutting Down")
         socketio.stop()
         print("Shutdown")
-
+    if (retval == "TurnOffRPI"):
+        print("Turning off RPI")
+        os.system('sudo poweroff')
 
 @socketio.on("settingRequest", namespace="/MaslowCNC")
 def settingRequest(msg):

--- a/templates/actions.html
+++ b/templates/actions.html
@@ -22,7 +22,7 @@
 				<button type="button" class="btn btn-lg btn-block btn-secondary" onclick="requestPage('restoreWebControl');$('#contentModal').modal('hide');">Restore WebControl</button>
 				<button type="button" class="btn btn-lg btn-block btn-secondary" onclick="action('clearLogs');$('#contentModal').modal('hide');">Clear Log Files</button>
 				<button type="button" class="btn btn-lg btn-block btn-danger" onclick="action('shutdown');$('#contentModal').modal('hide');">{{'Shutdown WebControl/WebMCP' if docker else 'Shutdown WebControl'}}</button>
-				<button type="button" class="btn btn-lg btn-block btn-danger" onclick="action('TurnOffRPI');$('#contentModal').modal('hide');">{{'Turn Off RPI'}}</button>
+				<button type="button" class="btn btn-lg btn-block btn-danger" {{'' if enableRPIshutdown else 'data-toggle="tooltip" title="Raspberry Pi System Shutdown"' | safe}} onclick="action('TurnOffRPI');$('#contentModal').modal('hide');"{{'' if enableRPIshutdown else 'hidden'}}>Turn off RPI</button>
 			</div>
 		</div>
 	</div>

--- a/templates/actions.html
+++ b/templates/actions.html
@@ -22,6 +22,7 @@
 				<button type="button" class="btn btn-lg btn-block btn-secondary" onclick="requestPage('restoreWebControl');$('#contentModal').modal('hide');">Restore WebControl</button>
 				<button type="button" class="btn btn-lg btn-block btn-secondary" onclick="action('clearLogs');$('#contentModal').modal('hide');">Clear Log Files</button>
 				<button type="button" class="btn btn-lg btn-block btn-danger" onclick="action('shutdown');$('#contentModal').modal('hide');">{{'Shutdown WebControl/WebMCP' if docker else 'Shutdown WebControl'}}</button>
+				<button type="button" class="btn btn-lg btn-block btn-danger" onclick="action('TurnOffRPI');$('#contentModal').modal('hide');">{{'Turn Off RPI'}}</button>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Added RPI shutdown button to action menu in actions.html.  RPI OS is set in data.py file.  verified and if platform = RPI or PYINSTALLER, then the button is visible.  webPageProcessor has enableRPIshutdown boolean variable that gets passed when actions.html gets rendered.  The actions.py file has a check for turnOffRPI which then callls subprocess.call('sudo --non-interactive shutdown -h now') command to turn off the raspberry pi.  