### PR TITLE
Issue #133 description of advanced setting: default chain extension length should be 1651 not 1650

### DIFF
--- a/File/wiicontrol.code-workspace
+++ b/File/wiicontrol.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": ".."
+		}
+	],
+	"settings": {}
+}

--- a/defaultwebcontrol.json
+++ b/defaultwebcontrol.json
@@ -91,7 +91,7 @@
         },
         {
             "default": 1651,
-            "desc": "The length in mm that will be extended during chain calibration\ndefault setting: 1650",
+            "desc": "The length in mm that will be extended during chain calibration\ndefault setting: 1651",
             "firmwareKey": 11,
             "key": "chainExtendLength",
             "section": "Advanced Settings",


### PR DESCRIPTION
changed the description in default webcontrol.json from 1650 to 1651.