### PR TITLE
Tweaks to readme and requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,17 +169,17 @@ docker run -it -v $HOME/.WebControl:/root/.WebControl -p 5000:5000 --privileged 
 You can use virtualenv to set up a local development environment for running the code without installing packages in the system Python installation.
 
     # Create a virtual environment
-    `virtualenv -p python3 .venv`
+    virtualenv -p python3 .venv
     # Activate the virtual environment
-    `source .venv/bin/activate`
+    source .venv/bin/activate
     # Install the prerequisites
-    `pip install -r requirements.txt`
+    pip install -r requirements.txt
 
 When running on the Pi, you'll also need some extra dependencies and will need to build OpenCV from source. See the Dockerfile for details. (TODO: add instructions here)
 
 Then you can run the code with.
 
-    `python main.py`
+    python main.py
 
 The server will then be available at http://localhost:5000
 

--- a/README.md
+++ b/README.md
@@ -169,19 +169,25 @@ docker run -it -v $HOME/.WebControl:/root/.WebControl -p 5000:5000 --privileged 
 You can use virtualenv to set up a local development environment for running the code without installing packages in the system Python installation.
 
     # Create a virtual environment
-    virtualenv -p python3 .venv 
+    `virtualenv -p python3 .venv`
     # Activate the virtual environment
-    source .venv/bin/activate
+    `source .venv/bin/activate`
     # Install the prerequisites
-    pip install -r requirements.txt
+    `pip install -r requirements.txt`
 
 When running on the Pi, you'll also need some extra dependencies and will need to build OpenCV from source. See the Dockerfile for details. (TODO: add instructions here)
 
 Then you can run the code with.
 
-    python main.py
+    `python main.py`
 
 The server will then be available at http://localhost:5000
+
+* If you get the following error after trying `python main.py`
+    `ImportError: libSM.so.6: cannot open shared object file: No such file or directory`
+
+    Then try the following:
+    `sudo apt-get install libsm6 libxrender1 libfontconfig1`
 
 ### Docker
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ gevent==1.3.7
 greenlet==0.4.15
 itsdangerous==0.24
 Jinja2>=2.10.1
-MarkupSafe==1.0
+MarkupSafe==1.1
 numpy==1.16.2
 scipy==1.3.1
 opencv-python==3.4.3.18


### PR DESCRIPTION
I found a couple of things that needed cleaning up (relative to my system - WSL running Ubuntu 18.04).

MarkupSafe v1.0 has a bug - so upgrade to v1.1

And some trouble shooting instructions for the Readme