### PR TITLE
Fix Webbrowser.open no longer working

### DIFF
--- a/main.py
+++ b/main.py
@@ -773,7 +773,7 @@ if __name__ == "__main__":
 
     print("opening browser")
     webPortStr = str(webPortInt)
-    webbrowser.open_new_tab("//localhost:"+webPortStr)
+    webbrowser.open_new_tab("http://localhost:"+webPortStr)
     host_name = socket.gethostname()
     host_ip = socket.gethostbyname(host_name)
     app.data.hostAddress = host_ip + ":" + webPortStr


### PR DESCRIPTION
Revert change to webbrowser.open_new_tab() which stops browser from opening WebControl as URL "//localhost:5000" is not understood.