### PR TITLE
convert all lower case gcode commands to upper case for browser display

### DIFF
--- a/File/gcodeFile.py
+++ b/File/gcodeFile.py
@@ -617,7 +617,7 @@ class GCodeFile(MakesmithInitFuncs):
         ]
 
         fullString = (
-            fullString + " "
+            fullString.upper() + " "
         )  # ensures that there is a space at the end of the line
         # find 'G' anywhere in string
 

--- a/File/wiicontrol.code-workspace
+++ b/File/wiicontrol.code-workspace
@@ -1,8 +1,0 @@
-{
-	"folders": [
-		{
-			"path": ".."
-		}
-	],
-	"settings": {}
-}


### PR DESCRIPTION
added .upper() for fullstring at line 620 in GcodeFlie.py

deleted needless workspace file from earlier merge

Tested this on fake servo mode system.  Used these maslow logo drawings a user said did not work.  Tested the drawings.  The modified gcode one with lower case gcode commands did not show on the visual display with the existing webcontrol code.  The added code fix did show the logo in both files in the browser cut display area.  Both files are attached for reference.

[CutFiles.zip](https://github.com/WebControlCNC/WebControl/files/5045192/CutFiles.zip)

