### PR TITLE
Arduino Mega spindle pwm control advanced settings

### DIFF
--- a/DataStructures/data.py
+++ b/DataStructures/data.py
@@ -35,6 +35,12 @@ class Data:
     controllerFirmwareVersion = 0
 
     '''
+    interpreter version
+    if using a compiler newer than 3.5, use the newer string format methods without %'s
+    '''
+    pythonVersion35 = False  
+    
+    '''l
     Version Updater
     '''
     lastChecked = -1

--- a/DataStructures/data.py
+++ b/DataStructures/data.py
@@ -33,7 +33,6 @@ class Data:
     customFirmwareVersion = None
     holeyFirmwareVersion = None
     controllerFirmwareVersion = 0
-
     '''
     interpreter version
     if using a compiler newer than 3.5, use the newer string format methods without %'s

--- a/defaultwebcontrol.json
+++ b/defaultwebcontrol.json
@@ -121,19 +121,41 @@
         },
         {
             "default": "None",
-            "desc": "How should the spindle start and stop automatically based on gcode? Leave off for none, or set external servo control, or external relay control, active high or low.\ndefault setting: None",
+            "desc": "How should the spindle start and stop automatically based on gcode? Leave off for none, or set external servo control, or external relay control, active high or low.  Speed control uses pin 45 in 51.29 firmware\ndefault setting: None",
             "firmwareKey": 17,
             "key": "spindleAutomate",
             "options": [
                 "None",
                 "Servo",
                 "Relay_High",
-                "Relay_Low"
+                "Relay_Low",
+                "SPEED_CTRL_RELAY_HIGH",
+                "SPEED_CTRL_RELAY_LOW"
             ],
             "section": "Advanced Settings",
             "title": "Spindle Automation",
             "type": "options",
             "value": "None"
+        },
+        {
+            "default": "None",
+            "desc": "Spindle start speed absolute minimum\ndefault setting: 4000",
+            "firmwareKey": 60,
+            "key": "spindleMin",
+            "section": "Advanced Settings",
+            "title": "Spindle Speed Minimum",
+            "type": "string",
+            "value": "4000"
+        },
+        {
+            "default": "None",
+            "desc": "Spindle maximum speed\ndefault setting: 24000",
+            "firmwareKey": 61,
+            "key": "spindleMax",
+            "section": "Advanced Settings",
+            "title": "Spindle Speed Maximum",
+            "type": "string",
+            "value": "24000"
         },
         {
             "default": 800,


### PR DESCRIPTION
Added 2 modes for spindle power switching so now they are:
-None
-Servo
-Relay High
-Relay Low
-Speed Relay High
-Speed Relay Low
(menu screen shot)
![image](https://user-images.githubusercontent.com/59507087/93009070-d563fa80-f541-11ea-9421-a968935a62f0.png)

The speed options will activate pin 45 in the firmware to output a scaled pwm signal mapped to 0 to max spindle speed with a power-on speed of spindle minimum.

spindle max and spindle min are editable settings in advanced settings as well.
![image](https://user-images.githubusercontent.com/59507087/93009063-caa96580-f541-11ea-816a-14938a127a35.png)

The speed controls only work if the speed mode is enabled and the spindle activates and deactivates via a relay as before with the M3 and M5 commands.  The S4000 command is to set the spindle speed to 4000.  Additional testing is required to verify it all works.